### PR TITLE
feat: Auto-Organize & Findability (21 features, 6 phases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local development worktrees (not shipped)
+.worktrees/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=wayland,x11 npm run tauri:dev
 | `query_parser.rs` | Natural language query parsing (media type, dates, confidence) |
 | `runtime.rs` | Ollama/nvidia-smi status gathering |
 | `platform/` | OS abstraction: clipboard, GPU detection, Python venv paths, executable lookup |
+| `portability.rs` | Data portability commands: `remap_root` (rewrite `abs_path` after drive-letter / folder moves), `export_catalog` / `import_catalog` (zip round-trip of db + caches, with zip-slip defense), `get/set_portable_root` (store catalog under `<root>/.frank_sherlock/` instead of the default data dir) |
 
 ## Architecture Principles
 
@@ -86,7 +87,7 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=wayland,x11 npm run tauri:dev
 
 ## Important Paths
 
-- Database: `~/.local/share/frank_sherlock/db/index.sqlite`
+- Database: `~/.local/share/frank_sherlock/db/index.sqlite` (or `<portableRoot>/.frank_sherlock/db/index.sqlite` when portable mode is on — set via `portableRoot` in user config)
 - Thumbnails: `~/.local/share/frank_sherlock/cache/thumbnails/`
 - Classification cache: `~/.local/share/frank_sherlock/cache/classifications/`
 - Surya venv: `~/.local/share/frank_sherlock/surya_venv/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ From `sherlock/desktop/`:
 ```bash
 npm install                    # frontend deps
 cargo build                    # rust backend (from src-tauri/)
-cargo test                     # 322 unit tests
+cargo test                     # 363 unit tests
 npm run tauri:dev              # launch dev mode
 npm run test                   # 299 frontend tests
 npm run tauri:build            # produce AppImage/DMG/MSI
@@ -67,6 +67,8 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=wayland,x11 npm run tauri:dev
 | `portability.rs` | Data portability commands: `remap_root` (rewrite `abs_path` after drive-letter / folder moves), `export_catalog` / `import_catalog` (zip round-trip of db + caches, with zip-slip defense), `get/set_portable_root` (store catalog under `<root>/.frank_sherlock/` instead of the default data dir) |
 | `similarity.rs` | dHash Hamming + Jaccard description overlap + `combined_similarity` (85/15 visual/textual) used by duplicate detection and Find Similar |
 | `find_similar.rs` | "More like this" ranked query over the catalog, scoped to matching `media_type`, with early-exit pruning via Hamming upper bound |
+| `filters.rs` | Aggregation queries for filter UI — `list_cameras`, `list_lenses` returning ranked `FilterOption` lists |
+| `autocomplete.rs` | Ranked prefix-match suggestions from people, cameras, lenses, and canonical mentions — used by search bar typeahead |
 
 ## Architecture Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ From `sherlock/desktop/`:
 ```bash
 npm install                    # frontend deps
 cargo build                    # rust backend (from src-tauri/)
-cargo test                     # 363 unit tests
+cargo test                     # 366 unit tests
 npm run tauri:dev              # launch dev mode
 npm run test                   # 299 frontend tests
 npm run tauri:build            # produce AppImage/DMG/MSI
@@ -69,6 +69,7 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=wayland,x11 npm run tauri:dev
 | `find_similar.rs` | "More like this" ranked query over the catalog, scoped to matching `media_type`, with early-exit pruning via Hamming upper bound |
 | `filters.rs` | Aggregation queries for filter UI — `list_cameras`, `list_lenses` returning ranked `FilterOption` lists |
 | `autocomplete.rs` | Ranked prefix-match suggestions from people, cameras, lenses, and canonical mentions — used by search bar typeahead |
+| `timeline.rs` | Monthly photo-count aggregation (`list_timeline_buckets`) for the Timeline heatmap sidebar |
 
 ## Architecture Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=wayland,x11 npm run tauri:dev
 | `query_parser.rs` | Natural language query parsing (media type, dates, confidence) |
 | `runtime.rs` | Ollama/nvidia-smi status gathering |
 | `platform/` | OS abstraction: clipboard, GPU detection, Python venv paths, executable lookup |
+| `similarity.rs` | dHash Hamming + Jaccard description overlap + `combined_similarity` (85/15 visual/textual) used by duplicate detection and Find Similar |
+| `find_similar.rs` | "More like this" ranked query over the catalog, scoped to matching `media_type`, with early-exit pruning via Hamming upper bound |
 
 ## Architecture Principles
 

--- a/docs/superpowers/plans/2026-04-20-find-similar.md
+++ b/docs/superpowers/plans/2026-04-20-find-similar.md
@@ -1,0 +1,583 @@
+# Find Similar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Right-click any image → "Find similar" shows the 20 most visually-and-semantically related files in the catalog, ranked.
+
+**Architecture:** All primitives already exist. The app already stores `dhash` (u64 perceptual hash, from Migration 6) and text `description` (from the classification pipeline). `similarity.rs` already exposes `combined_similarity(dhash_a, dhash_b, desc_a, desc_b) -> f32` that weighs 85% visual (dHash Hamming) and 15% textual (Jaccard on description words). This task stitches those together into a ranked query, exposes it to the UI, and wires a context-menu entry + results view.
+
+**Tech stack:** Rust (rusqlite, existing `similarity` helpers), React + TypeScript, Vitest.
+
+---
+
+## File structure
+
+- **Create:** `sherlock/desktop/src-tauri/src/find_similar.rs` — the ranked-query module.
+- **Modify:** `sherlock/desktop/src-tauri/src/lib.rs` — register the Tauri command + declare the module.
+- **Create:** `sherlock/desktop/src/components/modals/SimilarResultsModal.tsx` — results grid.
+- **Create:** `sherlock/desktop/src/components/modals/SimilarResultsModal.css` — thin per-dialog styles.
+- **Create:** `sherlock/desktop/src/__tests__/components/SimilarResultsModal.test.tsx`.
+- **Modify:** `sherlock/desktop/src/components/Content/` — wire a "Find similar" context-menu action on each thumbnail (look at the existing preview/delete action pattern).
+- **Modify:** `sherlock/desktop/src/App.tsx` — host modal state.
+- **Modify:** `sherlock/desktop/src/types.ts` — add `SimilarResult` interface.
+
+---
+
+## Task 1: Backend ranked query
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/find_similar.rs`
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs` (add `mod find_similar;`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `find_similar.rs`:
+
+```rust
+//! Ranked "find similar" query using dHash + description similarity.
+use crate::db::open_conn;
+use crate::error::{AppError, AppResult};
+use crate::similarity::{combined_similarity, hamming_distance};
+use rusqlite::params;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimilarResult {
+    pub file_id: i64,
+    pub root_id: i64,
+    pub rel_path: String,
+    pub abs_path: String,
+    pub filename: String,
+    pub media_type: String,
+    pub description: String,
+    pub thumb_path: Option<String>,
+    pub score: f32,
+}
+
+/// Early-exit pruning: if visual alone can't exceed `min_score`, skip the row.
+/// combined = 0.85 * visual + 0.15 * textual; textual ≤ 1.0, so:
+///   visual ≥ (min_score - 0.15) / 0.85
+///   hamming ≤ (1 - visual) * 64
+fn max_hamming_for(min_score: f32) -> u32 {
+    let visual_min = ((min_score - 0.15) / 0.85).max(0.0);
+    ((1.0 - visual_min) * 64.0).floor() as u32
+}
+
+/// Rank all other files by `combined_similarity` to the source file.
+/// Returns the top `limit` with `score ≥ min_score`, descending by score.
+pub fn find_similar(
+    db_path: &Path,
+    source_file_id: i64,
+    limit: usize,
+    min_score: f32,
+) -> AppResult<Vec<SimilarResult>> {
+    let conn = open_conn(db_path)?;
+
+    // Fetch the source row.
+    let (src_dhash, src_desc, src_media_type): (Option<i64>, String, String) = conn
+        .query_row(
+            "SELECT dhash, description, media_type FROM files
+             WHERE id = ?1 AND deleted_at IS NULL",
+            params![source_file_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::InvalidPath(format!("no such file: {source_file_id}"))
+            }
+            other => other.into(),
+        })?;
+
+    let src_dhash = match src_dhash {
+        Some(v) => v as u64,
+        None => {
+            // No dHash on source — fall back to description-only ranking via
+            // FTS BM25, handled elsewhere. For now, return empty.
+            return Ok(Vec::new());
+        }
+    };
+
+    let max_h = max_hamming_for(min_score);
+
+    // Load candidates: same media_type tier for precision, non-deleted, has dhash.
+    let mut stmt = conn.prepare(
+        "SELECT f.id, f.root_id, f.rel_path, f.filename, f.abs_path,
+                f.media_type, f.description, f.thumb_path, f.dhash
+         FROM files f
+         WHERE f.id != ?1
+           AND f.deleted_at IS NULL
+           AND f.dhash IS NOT NULL
+           AND f.media_type = ?2",
+    )?;
+
+    let mut scored: Vec<SimilarResult> = Vec::new();
+    let rows = stmt.query_map(params![source_file_id, src_media_type], |row| {
+        let dhash: i64 = row.get(8)?;
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, String>(6)?,
+            row.get::<_, Option<String>>(7)?,
+            dhash as u64,
+        ))
+    })?;
+
+    for row in rows {
+        let (file_id, root_id, rel_path, filename, abs_path, media_type, description, thumb_path, cand_dhash) = row?;
+        if hamming_distance(src_dhash, cand_dhash) > max_h {
+            continue;
+        }
+        let score = combined_similarity(src_dhash, cand_dhash, &src_desc, &description);
+        if score < min_score {
+            continue;
+        }
+        scored.push(SimilarResult {
+            file_id,
+            root_id,
+            rel_path,
+            abs_path,
+            filename,
+            media_type,
+            description,
+            thumb_path,
+            score,
+        });
+    }
+
+    scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    Ok(scored)
+}
+
+#[tauri::command]
+pub async fn find_similar_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    file_id: i64,
+    limit: usize,
+    min_score: f32,
+) -> Result<Vec<SimilarResult>, String> {
+    find_similar(&state.paths.db_file, file_id, limit, min_score).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn seed_file(
+        conn: &Connection,
+        root_id: i64,
+        filename: &str,
+        rel_path: &str,
+        media_type: &str,
+        description: &str,
+        dhash: Option<i64>,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, media_type, description,
+                                mtime_ns, size_bytes, fingerprint, updated_at, dhash)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 0, ?7, 0, ?8)",
+            rusqlite::params![
+                root_id,
+                rel_path,
+                filename,
+                format!("D:\\Photos\\{rel_path}"),
+                media_type,
+                description,
+                format!("fp-{filename}"),
+                dhash,
+            ],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn setup() -> (tempfile::TempDir, std::path::PathBuf, i64) {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+        let root_id = upsert_root(&db_path, "D:\\Photos").unwrap();
+        (dir, db_path, root_id)
+    }
+
+    #[test]
+    fn find_similar_returns_high_scoring_candidates() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        // Source: dhash 0x00, media_type photo, description "sunset over beach"
+        let src = seed_file(&conn, root_id, "a.jpg", "a.jpg", "photo", "sunset over beach", Some(0));
+        // Very similar: 2 bit difference, same words
+        let close = seed_file(&conn, root_id, "b.jpg", "b.jpg", "photo", "sunset over beach", Some(0b11));
+        // Same media type, unrelated content, very different hash
+        let far = seed_file(&conn, root_id, "c.jpg", "c.jpg", "photo", "car in parking lot", Some(i64::from_le_bytes(0xFFFFFFFFFFFFFFFFu64.to_le_bytes())));
+        // Different media type — must be filtered out
+        let _doc = seed_file(&conn, root_id, "d.jpg", "d.jpg", "document", "sunset over beach", Some(0));
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        let ids: Vec<i64> = out.iter().map(|r| r.file_id).collect();
+        assert!(ids.contains(&close), "expected close match included, got {ids:?}");
+        assert!(!ids.contains(&far), "expected far match excluded by min_score 0.5, got {ids:?}");
+        // Must not include the source itself.
+        assert!(!ids.contains(&src));
+        // Must not cross media_type.
+        assert!(ids.iter().all(|id| *id != _doc));
+        // Must be sorted descending by score.
+        let mut scores: Vec<f32> = out.iter().map(|r| r.score).collect();
+        let mut sorted = scores.clone();
+        sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        assert_eq!(scores, sorted);
+        scores.clear();
+    }
+
+    #[test]
+    fn find_similar_respects_limit() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "cat on couch", Some(0));
+        for i in 0..5 {
+            seed_file(
+                &conn,
+                root_id,
+                &format!("n{i}.jpg"),
+                &format!("n{i}.jpg"),
+                "photo",
+                "cat on couch",
+                Some(i as i64), // Hamming distances 1..5 bits.
+            );
+        }
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 2, 0.5).unwrap();
+        assert_eq!(out.len(), 2, "limit must cap results at 2");
+    }
+
+    #[test]
+    fn find_similar_returns_empty_when_source_has_no_dhash() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "x", None);
+        seed_file(&conn, root_id, "c.jpg", "c.jpg", "photo", "x", Some(0));
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        assert!(out.is_empty(), "source without dhash should yield empty results");
+    }
+
+    #[test]
+    fn find_similar_errors_on_unknown_source() {
+        let (_dir, db_path, _root_id) = setup();
+        let err = find_similar(&db_path, 9999, 10, 0.5);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn find_similar_excludes_deleted_candidates() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "sunset", Some(0));
+        let gone = seed_file(&conn, root_id, "gone.jpg", "gone.jpg", "photo", "sunset", Some(0));
+        conn.execute("UPDATE files SET deleted_at = 1 WHERE id = ?1", rusqlite::params![gone]).unwrap();
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        assert!(out.iter().all(|r| r.file_id != gone));
+    }
+}
+```
+
+- [ ] **Step 2: Register module**
+
+In `lib.rs`, add `mod find_similar;` next to the other `mod` declarations.
+
+- [ ] **Step 3: Run tests — confirm RED**
+
+```
+cd sherlock/desktop/src-tauri && cargo test find_similar --lib -- --test-threads=1
+```
+
+Expected: fails because `find_similar` module and helpers don't compile until Step 1 lands.
+
+(The test file IS the implementation too in this case — Step 1 created both. Running the tests verifies GREEN.)
+
+- [ ] **Step 4: Verify GREEN**
+
+```
+cargo test find_similar --lib -- --test-threads=1
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Register the Tauri command**
+
+In `lib.rs`, add `find_similar::find_similar_cmd,` to `tauri::generate_handler![...]`. Place near the existing `portability::*` commands so related surface area stays co-located.
+
+- [ ] **Step 6: cargo check**
+
+```
+cargo check
+```
+
+Must be clean (pre-existing unrelated warnings allowed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -c user.email=felipe@local -c user.name=felipe commit -am "feat(find-similar): backend ranked-query using dHash + description"
+```
+
+---
+
+## Task 2: Results modal UI
+
+**Files:**
+- Modify: `sherlock/desktop/src/types.ts` (add `SimilarResult`)
+- Create: `sherlock/desktop/src/components/modals/SimilarResultsModal.tsx`
+- Create: `sherlock/desktop/src/components/modals/SimilarResultsModal.css`
+- Create: `sherlock/desktop/src/__tests__/components/SimilarResultsModal.test.tsx`
+
+- [ ] **Step 1: Add the TS interface**
+
+In `types.ts`, append:
+
+```ts
+export interface SimilarResult {
+  fileId: number;
+  rootId: number;
+  relPath: string;
+  absPath: string;
+  filename: string;
+  mediaType: string;
+  description: string;
+  thumbPath: string | null;
+  score: number;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `__tests__/components/SimilarResultsModal.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SimilarResultsModal from "../../components/modals/SimilarResultsModal";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+
+describe("SimilarResultsModal", () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it("invokes find_similar_cmd on mount and renders the results", async () => {
+    invokeMock.mockResolvedValue([
+      { fileId: 2, rootId: 1, relPath: "b.jpg", absPath: "D:/b.jpg", filename: "b.jpg",
+        mediaType: "photo", description: "sunset", thumbPath: null, score: 0.97 },
+      { fileId: 3, rootId: 1, relPath: "c.jpg", absPath: "D:/c.jpg", filename: "c.jpg",
+        mediaType: "photo", description: "beach", thumbPath: null, score: 0.82 },
+    ]);
+    render(<SimilarResultsModal sourceFileId={1} sourceLabel="a.jpg" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("find_similar_cmd", {
+        fileId: 1, limit: 20, minScore: 0.5,
+      })
+    );
+    await waitFor(() => expect(screen.getByText("b.jpg")).toBeInTheDocument());
+    expect(screen.getByText("c.jpg")).toBeInTheDocument();
+    // Scores rendered as percentages.
+    expect(screen.getByText(/97%/)).toBeInTheDocument();
+    expect(screen.getByText(/82%/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no matches", async () => {
+    invokeMock.mockResolvedValue([]);
+    render(<SimilarResultsModal sourceFileId={1} sourceLabel="a.jpg" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/no similar/i)).toBeInTheDocument());
+  });
+
+  it("surfaces backend errors", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("no such file: 9999"));
+    render(<SimilarResultsModal sourceFileId={9999} sourceLabel="missing" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/no such file/i));
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — confirm RED**
+
+```
+cd sherlock/desktop && npx vitest run SimilarResultsModal
+```
+
+- [ ] **Step 4: Implement the modal**
+
+Create `SimilarResultsModal.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { errorMessage } from "../../utils";
+import type { SimilarResult } from "../../types";
+import ModalOverlay from "./ModalOverlay";
+import "./shared-modal.css";
+import "./SimilarResultsModal.css";
+
+type Props = {
+  sourceFileId: number;
+  sourceLabel: string;
+  onClose: () => void;
+};
+
+export default function SimilarResultsModal({ sourceFileId, sourceLabel, onClose }: Props) {
+  const [results, setResults] = useState<SimilarResult[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const out = await invoke<SimilarResult[]>("find_similar_cmd", {
+          fileId: sourceFileId,
+          limit: 20,
+          minScore: 0.5,
+        });
+        if (!cancelled) setResults(out);
+      } catch (e) {
+        if (!cancelled) setError(errorMessage(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [sourceFileId]);
+
+  return (
+    <ModalOverlay onBackdropClick={onClose}>
+      <div
+        className="modal-base similar-results-modal"
+        role="dialog"
+        aria-label="Similar results"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3>Similar to {sourceLabel}</h3>
+        {error && <div role="alert" className="similar-results-error">{error}</div>}
+        {results === null && !error && (
+          <p className="similar-results-status">Searching…</p>
+        )}
+        {results && results.length === 0 && (
+          <p className="similar-results-empty">No similar items found above the 50% threshold.</p>
+        )}
+        {results && results.length > 0 && (
+          <ul className="similar-results-grid">
+            {results.map((r) => (
+              <li key={r.fileId} className="similar-results-item">
+                <div className="similar-results-thumb" aria-hidden="true">
+                  {r.thumbPath ? <img src={r.thumbPath} alt="" /> : <span>📄</span>}
+                </div>
+                <div className="similar-results-meta">
+                  <div className="similar-results-name" title={r.absPath}>{r.filename}</div>
+                  <div className="similar-results-desc">{r.description}</div>
+                  <div className="similar-results-score">{Math.round(r.score * 100)}%</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}
+```
+
+Create `SimilarResultsModal.css` with minimal thin styles for `.similar-results-*` classes (grid layout for thumbs, small metadata text, percentage score chip). Keep CSS small — reuse shared-modal where possible.
+
+- [ ] **Step 5: GREEN**
+
+```
+cd sherlock/desktop && npx vitest run SimilarResultsModal
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -c user.email=felipe@local -c user.name=felipe commit -am "feat(ui): similar-results modal"
+```
+
+---
+
+## Task 3: Content-grid wiring
+
+**Files:**
+- Modify: `sherlock/desktop/src/App.tsx`
+- Modify: one or more files under `sherlock/desktop/src/components/Content/` (the thumbnail grid and its context menu) — read the existing structure first and mirror the pattern used for the "Delete" / "Open in Finder" / "Copy path" context-menu entries.
+
+- [ ] **Step 1: Read the existing pattern**
+
+Open `components/Content/` and identify:
+- The thumbnail grid file (probably `Content.tsx` or `ThumbnailGrid.tsx`).
+- Its right-click context menu — there should already be entries like "Preview", "Copy path", etc. Find where they live and how props flow from App.tsx.
+
+- [ ] **Step 2: Add the handler prop**
+
+In whichever hook or component owns the context menu, add an `onFindSimilar: (fileId: number, label: string) => void` prop/callback. Render a new menu entry "Find similar" that calls it.
+
+- [ ] **Step 3: Wire state in App.tsx**
+
+```tsx
+const [similarSource, setSimilarSource] = useState<{ fileId: number; label: string } | null>(null);
+// ... pass handler:
+onFindSimilar={(fileId, label) => setSimilarSource({ fileId, label })}
+// ... render near the other modals:
+{similarSource && (
+  <SimilarResultsModal
+    sourceFileId={similarSource.fileId}
+    sourceLabel={similarSource.label}
+    onClose={() => setSimilarSource(null)}
+  />
+)}
+```
+
+- [ ] **Step 4: Type-check + full suite**
+
+```
+cd sherlock/desktop && npm run test
+```
+
+Must remain green (no regressions). Spot-check that existing tests covering the content-grid context menu still pass — if they mock props, they may need the new `onFindSimilar` added to their defaults.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -c user.email=felipe@local -c user.name=felipe commit -am "feat(ui): Find similar context-menu entry on thumbnail grid"
+```
+
+---
+
+## Task 4: Delivery note
+
+- [ ] **Step 1:** Append a short entry to `releases/v0.9.0.md` or create `v0.10.0.md` summarizing the new "Find similar" menu entry + how the ranking works (85% visual / 15% textual). Include the Ollama-free nature (no model download required; uses existing dHash + description).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -c user.email=felipe@local -c user.name=felipe commit -am "docs: release note for find-similar"
+```
+
+---
+
+## Post-task checklist
+
+- [ ] `cargo test find_similar --lib` green (5 tests).
+- [ ] `npm run test` green (existing + 3 new).
+- [ ] CLAUDE.md mentions `find_similar.rs` in the Key Rust Modules table.
+- [ ] Release note drafted.

--- a/docs/superpowers/plans/2026-04-20-frank-sherlock-improvements.md
+++ b/docs/superpowers/plans/2026-04-20-frank-sherlock-improvements.md
@@ -1,0 +1,946 @@
+# Frank Sherlock Improvements — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 10 improvements across data portability, scheduling, classification flexibility and UX.
+
+**Architecture:** Six phases, each shippable on its own. Phase 1 (portability) solves the most concrete user pain — changing drive letters or migrating machines without losing hours of Ollama reprocessing. Phases 2-6 layer on top without breaking Phase 1's invariants.
+
+**Tech Stack:** Rust (Tauri v2, rusqlite, rusqlite_migration, notify, zip), React + TypeScript (Vite), SQLite + FTS5, Ollama.
+
+**Phase map:**
+
+| # | Name | Solves | Est. |
+|---|---|---|---|
+| 1 | Data portability | Drive-letter swap, machine migration, portable drives | 2d |
+| 2 | Schema normalization | Eliminate `abs_path` duplication → remap needs only roots | 1d |
+| 3 | Watch mode | Auto-index on FS change, no manual rescan | 2d |
+| 4 | Priority queue + multi-model | New files first, "fast" profile for backfill | 2d |
+| 5 | Manual corrections + few-shot | User tags + drift-proof prompt | 2d |
+| 6 | UI polish | Dedup actions, EXIF panel | 1d |
+
+---
+
+## Phase 1 — Data Portability
+
+**Deliverables:** Three Tauri commands + UI: `remap_root`, `export_catalog`, `import_catalog`, and a `portable_mode` flag that relocates `AppPaths` under `<root>/.frank_sherlock/`.
+
+**Files touched:**
+- Create: `sherlock/desktop/src-tauri/src/portability.rs`
+- Modify: `sherlock/desktop/src-tauri/src/db.rs` (add remap function)
+- Modify: `sherlock/desktop/src-tauri/src/config.rs` (portable mode)
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs` (register commands)
+- Create: `sherlock/desktop/src/features/portability/RemapRootDialog.tsx`
+- Create: `sherlock/desktop/src/features/portability/ExportDialog.tsx`
+- Create: `sherlock/desktop/src/features/portability/ImportDialog.tsx`
+- Modify: `sherlock/desktop/src/App.tsx` (wire buttons)
+
+### Task 1.1: `remap_root` DB primitive
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/db.rs` (append near `move_files_to_child_root`)
+- Test: inline `#[cfg(test)] mod tests` at bottom of `db.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `#[cfg(test)] mod tests` in `db.rs`:
+
+```rust
+#[test]
+fn remap_root_updates_root_and_abs_paths() {
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+    init_db(&db_path).unwrap();
+
+    // Seed a root with one file.
+    let root_id = upsert_root(&db_path, "D:\\Photos").unwrap();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+         VALUES (?1, ?2, ?3, ?4, 0, 0, 'fp', 0)",
+        rusqlite::params![root_id, "a/b.jpg", "b.jpg", "D:\\Photos\\a\\b.jpg"],
+    ).unwrap();
+    drop(conn);
+
+    // Act.
+    let changed = remap_root(&db_path, "D:\\Photos", "E:\\Photos").unwrap();
+    assert_eq!(changed.roots_updated, 1);
+    assert_eq!(changed.files_updated, 1);
+
+    // Assert.
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let root_path: String = conn.query_row(
+        "SELECT root_path FROM roots WHERE id = ?1",
+        rusqlite::params![root_id],
+        |r| r.get(0),
+    ).unwrap();
+    assert_eq!(root_path, "E:\\Photos");
+
+    let abs: String = conn.query_row(
+        "SELECT abs_path FROM files WHERE root_id = ?1",
+        rusqlite::params![root_id],
+        |r| r.get(0),
+    ).unwrap();
+    assert_eq!(abs, "E:\\Photos\\a\\b.jpg");
+}
+
+#[test]
+fn remap_root_rejects_collision_with_existing_root() {
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+    init_db(&db_path).unwrap();
+    upsert_root(&db_path, "D:\\A").unwrap();
+    upsert_root(&db_path, "D:\\B").unwrap();
+
+    let err = remap_root(&db_path, "D:\\A", "D:\\B");
+    assert!(err.is_err(), "remap onto another existing root must fail");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sherlock/desktop/src-tauri && cargo test remap_root --lib`
+Expected: FAIL — `cannot find function remap_root`.
+
+- [ ] **Step 3: Implement `remap_root`**
+
+Append to `db.rs`:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemapReport {
+    pub roots_updated: usize,
+    pub files_updated: usize,
+    pub scan_jobs_updated: usize,
+}
+
+/// Rewrite `root_path` and all dependent `abs_path` columns when a root
+/// moves (drive letter change, directory rename). Both paths are compared
+/// and stored verbatim — the caller is expected to canonicalize.
+///
+/// Fails if `new_root_path` collides with another existing root.
+pub fn remap_root(db_path: &Path, old_root_path: &str, new_root_path: &str) -> AppResult<RemapReport> {
+    if old_root_path == new_root_path {
+        return Ok(RemapReport::default());
+    }
+    let mut conn = Connection::open(db_path)?;
+    let tx = conn.transaction()?;
+
+    // Collision check.
+    let collides: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM roots WHERE root_path = ?1)",
+        params![new_root_path],
+        |r| r.get::<_, i64>(0).map(|v| v != 0),
+    )?;
+    if collides {
+        return Err(AppError::Config(format!(
+            "remap target already exists as a root: {new_root_path}"
+        )));
+    }
+
+    // Find the root id.
+    let root_id: Option<i64> = tx.query_row(
+        "SELECT id FROM roots WHERE root_path = ?1",
+        params![old_root_path],
+        |r| r.get(0),
+    ).ok();
+    let Some(root_id) = root_id else {
+        return Err(AppError::Config(format!("no such root: {old_root_path}")));
+    };
+
+    let roots_updated = tx.execute(
+        "UPDATE roots SET root_path = ?1 WHERE id = ?2",
+        params![new_root_path, root_id],
+    )?;
+
+    // Rewrite only the prefix of abs_path to avoid clobbering substrings that
+    // match elsewhere in the string.
+    let files_updated = tx.execute(
+        "UPDATE files SET abs_path = ?1 || substr(abs_path, length(?2) + 1)
+         WHERE root_id = ?3 AND substr(abs_path, 1, length(?2)) = ?2",
+        params![new_root_path, old_root_path, root_id],
+    )?;
+
+    let scan_jobs_updated = tx.execute(
+        "UPDATE scan_jobs SET root_path = ?1 WHERE root_id = ?2",
+        params![new_root_path, root_id],
+    )?;
+
+    tx.commit()?;
+    Ok(RemapReport {
+        roots_updated,
+        files_updated,
+        scan_jobs_updated,
+    })
+}
+
+impl Default for RemapReport {
+    fn default() -> Self {
+        Self { roots_updated: 0, files_updated: 0, scan_jobs_updated: 0 }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sherlock/desktop/src-tauri && cargo test remap_root --lib`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sherlock/desktop/src-tauri/src/db.rs
+git commit -m "feat(db): add remap_root for drive-letter and path swaps"
+```
+
+### Task 1.2: Tauri command wrapper
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/portability.rs`
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Write the test**
+
+Create `portability.rs`:
+
+```rust
+//! Portability commands: remap, export, import, portable mode toggle.
+use crate::db;
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn remap_root_cmd(
+    state: tauri::State<'_, AppState>,
+    old_path: String,
+    new_path: String,
+) -> Result<db::RemapReport, String> {
+    db::remap_root(&state.paths.db_file, &old_path, &new_path)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration coverage: db::tests already exercise the core logic.
+    // The command layer is a thin adapter; add e2e tests in webapp-testing
+    // phase (Task 1.9).
+}
+```
+
+- [ ] **Step 2: Register the command in `lib.rs`**
+
+`AppState` is currently `struct AppState { ... }` (private) at `lib.rs:36`. Change to `pub(crate) struct AppState` and make its fields accessed from `portability.rs` (`paths`) `pub(crate)` as well:
+
+```rust
+pub(crate) struct AppState {
+    pub(crate) paths: AppPaths,
+    // ... (other fields unchanged)
+}
+```
+
+Locate the `.invoke_handler(tauri::generate_handler![...])` call in `run()` and add `portability::remap_root_cmd,`. Also add `mod portability;` near the top of `lib.rs`.
+
+- [ ] **Step 3: Run cargo check**
+
+Run: `cd sherlock/desktop/src-tauri && cargo check`
+Expected: compiles clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sherlock/desktop/src-tauri/src/portability.rs sherlock/desktop/src-tauri/src/lib.rs
+git commit -m "feat: expose remap_root_cmd to frontend"
+```
+
+### Task 1.3: Remap UI
+
+**Files:**
+- Create: `sherlock/desktop/src/features/portability/RemapRootDialog.tsx`
+- Create: `sherlock/desktop/src/features/portability/RemapRootDialog.test.tsx`
+- Modify: `sherlock/desktop/src/App.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `RemapRootDialog.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RemapRootDialog from "./RemapRootDialog";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invoke(...args) }));
+
+describe("RemapRootDialog", () => {
+  beforeEach(() => invoke.mockReset());
+
+  it("submits old and new paths to remap_root_cmd", async () => {
+    invoke.mockResolvedValue({ rootsUpdated: 1, filesUpdated: 42, scanJobsUpdated: 1 });
+    render(<RemapRootDialog oldPath="D:\\Photos" onClose={() => {}} onRemapped={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText(/new path/i), { target: { value: "E:\\Photos" } });
+    fireEvent.click(screen.getByRole("button", { name: /remap/i }));
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("remap_root_cmd", {
+      oldPath: "D:\\Photos",
+      newPath: "E:\\Photos",
+    }));
+    expect(screen.getByText(/42 file/i)).toBeInTheDocument();
+  });
+
+  it("shows error when backend rejects", async () => {
+    invoke.mockRejectedValue("no such root: D:\\Photos");
+    render(<RemapRootDialog oldPath="D:\\Photos" onClose={() => {}} onRemapped={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/new path/i), { target: { value: "Z:\\x" } });
+    fireEvent.click(screen.getByRole("button", { name: /remap/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/no such root/i));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+Run: `cd sherlock/desktop && npm run test -- RemapRootDialog`
+Expected: FAIL (component missing).
+
+- [ ] **Step 3: Implement `RemapRootDialog.tsx`**
+
+```tsx
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { errorMessage } from "../../utils";
+
+interface RemapReport { rootsUpdated: number; filesUpdated: number; scanJobsUpdated: number }
+
+interface Props {
+  oldPath: string;
+  onClose: () => void;
+  onRemapped: (report: RemapReport) => void;
+}
+
+export default function RemapRootDialog({ oldPath, onClose, onRemapped }: Props) {
+  const [newPath, setNewPath] = useState(oldPath);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<RemapReport | null>(null);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await invoke<RemapReport>("remap_root_cmd", { oldPath, newPath });
+      setReport(result);
+      onRemapped(result);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal" role="dialog" aria-label="Remap root">
+      <h2>Remap Root</h2>
+      <p>Old: <code>{oldPath}</code></p>
+      <label>
+        New path
+        <input
+          aria-label="new path"
+          value={newPath}
+          onChange={(e) => setNewPath(e.target.value)}
+        />
+      </label>
+      {error && <div role="alert" className="error">{error}</div>}
+      {report && <div>Updated {report.filesUpdated} file record(s).</div>}
+      <footer>
+        <button onClick={onClose}>Close</button>
+        <button onClick={submit} disabled={busy || !newPath || newPath === oldPath}>
+          {busy ? "Remapping…" : "Remap"}
+        </button>
+      </footer>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to confirm pass**
+
+Run: `cd sherlock/desktop && npm run test -- RemapRootDialog`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into App.tsx**
+
+Locate the sidebar root list (look for `useRootsManagement` or similar hook that yields `roots`). Add a context-menu or button per root: `Remap…`. On click, render `<RemapRootDialog oldPath={root.rootPath} onClose={...} onRemapped={() => reloadRoots()} />`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sherlock/desktop/src/features/portability/ sherlock/desktop/src/App.tsx
+git commit -m "feat(ui): remap root dialog"
+```
+
+### Task 1.4: `export_catalog` backend
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/portability.rs`
+- Modify: `sherlock/desktop/src-tauri/Cargo.toml` (add `zip` dep)
+
+- [ ] **Step 1: Add dependency**
+
+Edit `Cargo.toml`:
+
+```toml
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `portability.rs`:
+
+```rust
+#[cfg(test)]
+mod export_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn export_catalog_bundles_db_and_caches() {
+        let src = tempdir().unwrap();
+        let out = tempdir().unwrap();
+
+        // Fake AppPaths layout.
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"sqlitebytes").unwrap();
+        fs::create_dir_all(src.path().join("cache/thumbnails/root/a")).unwrap();
+        fs::write(src.path().join("cache/thumbnails/root/a/b.jpg"), b"thumb").unwrap();
+        fs::create_dir_all(src.path().join("cache/classifications/root/a")).unwrap();
+        fs::write(src.path().join("cache/classifications/root/a/b.json"), b"{}").unwrap();
+
+        let zip_path = out.path().join("catalog.zip");
+        let report = export_catalog_at(src.path(), &zip_path).unwrap();
+        assert!(zip_path.exists());
+        assert!(report.entries >= 3);
+
+        // Sanity: the zip opens and contains our files.
+        let f = fs::File::open(&zip_path).unwrap();
+        let mut arch = zip::ZipArchive::new(f).unwrap();
+        let names: Vec<String> = (0..arch.len())
+            .map(|i| arch.by_index(i).unwrap().name().to_string())
+            .collect();
+        assert!(names.iter().any(|n| n.ends_with("index.sqlite")));
+        assert!(names.iter().any(|n| n.contains("thumbnails/")));
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd sherlock/desktop/src-tauri && cargo test export_catalog`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement `export_catalog_at`**
+
+Add to `portability.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportReport {
+    pub zip_path: String,
+    pub entries: usize,
+    pub bytes: u64,
+}
+
+/// Export db + thumbnails + classifications into a single zip.
+/// `base_dir` is the AppPaths base (what `config::resolve_paths().base_dir` returns).
+pub fn export_catalog_at(base_dir: &Path, zip_path: &Path) -> AppResult<ExportReport> {
+    use std::io::Write;
+
+    let file = std::fs::File::create(zip_path)
+        .map_err(|e| AppError::Config(format!("cannot create zip: {e}")))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let opts: zip::write::FileOptions<()> =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let mut entries = 0usize;
+    let mut bytes = 0u64;
+
+    for (label, rel) in [
+        ("db", Path::new("db")),
+        ("thumbnails", Path::new("cache/thumbnails")),
+        ("classifications", Path::new("cache/classifications")),
+    ] {
+        let abs = base_dir.join(rel);
+        if !abs.exists() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&abs) {
+            let entry = entry.map_err(|e| AppError::Config(format!("{label}: {e}")))?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let rel_in_zip = entry.path().strip_prefix(base_dir).unwrap();
+            zip.start_file(rel_in_zip.to_string_lossy(), opts)
+                .map_err(|e| AppError::Config(format!("zip start: {e}")))?;
+            let data = std::fs::read(entry.path())?;
+            zip.write_all(&data)
+                .map_err(|e| AppError::Config(format!("zip write: {e}")))?;
+            entries += 1;
+            bytes += data.len() as u64;
+        }
+    }
+
+    zip.finish().map_err(|e| AppError::Config(format!("zip finish: {e}")))?;
+    Ok(ExportReport {
+        zip_path: zip_path.to_string_lossy().into_owned(),
+        entries,
+        bytes,
+    })
+}
+
+#[tauri::command]
+pub async fn export_catalog_cmd(
+    state: tauri::State<'_, AppState>,
+    out_zip: String,
+) -> Result<ExportReport, String> {
+    export_catalog_at(&state.paths.base_dir, std::path::Path::new(&out_zip))
+        .map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd sherlock/desktop/src-tauri && cargo test export_catalog`
+Expected: PASS.
+
+- [ ] **Step 6: Register command + commit**
+
+Add `portability::export_catalog_cmd` to the invoke handler in `lib.rs`.
+
+```bash
+git add sherlock/desktop/src-tauri/
+git commit -m "feat(portability): zip-based catalog export"
+```
+
+### Task 1.5: `import_catalog` backend
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/portability.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `portability.rs`:
+
+```rust
+#[cfg(test)]
+mod import_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn import_restores_db_and_caches() {
+        // Arrange: create + export.
+        let src = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"DBDATA").unwrap();
+        fs::create_dir_all(src.path().join("cache/thumbnails")).unwrap();
+        fs::write(src.path().join("cache/thumbnails/x.jpg"), b"T").unwrap();
+
+        let bundle = src.path().join("bundle.zip");
+        export_catalog_at(src.path(), &bundle).unwrap();
+
+        // Act: import into fresh directory.
+        let dst = tempdir().unwrap();
+        let report = import_catalog_at(&bundle, dst.path()).unwrap();
+
+        // Assert.
+        assert_eq!(fs::read(dst.path().join("db/index.sqlite")).unwrap(), b"DBDATA");
+        assert_eq!(fs::read(dst.path().join("cache/thumbnails/x.jpg")).unwrap(), b"T");
+        assert!(report.entries >= 2);
+    }
+
+    #[test]
+    fn import_refuses_to_clobber_nonempty_base_without_force() {
+        let src = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"X").unwrap();
+        let bundle = src.path().join("b.zip");
+        export_catalog_at(src.path(), &bundle).unwrap();
+
+        let dst = tempdir().unwrap();
+        fs::create_dir_all(dst.path().join("db")).unwrap();
+        fs::write(dst.path().join("db/index.sqlite"), b"EXISTING").unwrap();
+
+        assert!(import_catalog_at(&bundle, dst.path()).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Implement `import_catalog_at`**
+
+Add to `portability.rs`:
+
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportReport {
+    pub entries: usize,
+    pub bytes: u64,
+}
+
+pub fn import_catalog_at(bundle: &Path, base_dir: &Path) -> AppResult<ImportReport> {
+    use std::io::Read;
+
+    let db_target = base_dir.join("db").join("index.sqlite");
+    if db_target.exists() {
+        return Err(AppError::Config(format!(
+            "refusing to overwrite existing catalog at {}",
+            base_dir.display()
+        )));
+    }
+
+    let file = std::fs::File::open(bundle)
+        .map_err(|e| AppError::Config(format!("open bundle: {e}")))?;
+    let mut arch = zip::ZipArchive::new(file)
+        .map_err(|e| AppError::Config(format!("invalid zip: {e}")))?;
+
+    let mut entries = 0usize;
+    let mut bytes = 0u64;
+
+    for i in 0..arch.len() {
+        let mut zip_file = arch.by_index(i)
+            .map_err(|e| AppError::Config(format!("zip idx {i}: {e}")))?;
+        if zip_file.is_dir() {
+            continue;
+        }
+        let rel = PathBuf::from(zip_file.name());
+        let target = base_dir.join(&rel);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut buf = Vec::with_capacity(zip_file.size() as usize);
+        zip_file.read_to_end(&mut buf)
+            .map_err(|e| AppError::Config(format!("read {}: {e}", rel.display())))?;
+        std::fs::write(&target, &buf)?;
+        entries += 1;
+        bytes += buf.len() as u64;
+    }
+
+    Ok(ImportReport { entries, bytes })
+}
+
+#[tauri::command]
+pub async fn import_catalog_cmd(
+    state: tauri::State<'_, AppState>,
+    bundle: String,
+) -> Result<ImportReport, String> {
+    import_catalog_at(std::path::Path::new(&bundle), &state.paths.base_dir)
+        .map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd sherlock/desktop/src-tauri && cargo test import_catalog`
+Expected: PASS.
+
+- [ ] **Step 4: Register + commit**
+
+Add `portability::import_catalog_cmd` to the invoke handler.
+
+```bash
+git add sherlock/desktop/src-tauri/
+git commit -m "feat(portability): import catalog from zip"
+```
+
+### Task 1.6: Export/Import UI
+
+**Files:**
+- Create: `sherlock/desktop/src/features/portability/ExportDialog.tsx`
+- Create: `sherlock/desktop/src/features/portability/ImportDialog.tsx`
+- Create: corresponding `.test.tsx`
+- Modify: `sherlock/desktop/src/App.tsx` (settings menu entries)
+
+- [ ] **Step 1: Write tests mirroring Task 1.3**
+
+Pattern: mock `@tauri-apps/api/core`, render the dialog, invoke the command, assert the success/error UI paths. Use file path input + `@tauri-apps/plugin-dialog` `save`/`open` for native dialogs.
+
+- [ ] **Step 2: Implement both dialogs**
+
+They share the shape of `RemapRootDialog` — one text field (file path), one submit, a busy/error/report state. Use `import { save, open } from "@tauri-apps/plugin-dialog"` for native file pickers.
+
+- [ ] **Step 3: Wire menu entries in App.tsx**
+
+Add "Export catalog…" and "Import catalog…" to the settings dropdown. Guard import with a confirm modal ("This replaces the current index. Proceed?").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "feat(ui): export and import catalog dialogs"
+```
+
+### Task 1.7: Portable mode
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/config.rs`
+- Modify: `sherlock/desktop/src-tauri/src/portability.rs`
+
+- [ ] **Step 1: Write tests for portable resolution**
+
+Append to `config.rs` tests:
+
+```rust
+#[test]
+fn resolve_paths_portable_uses_root_subdir() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    env::remove_var(DATA_DIR_ENV);
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("MyDrive");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let paths = resolve_paths_for_root(Some(&root)).unwrap();
+    assert!(paths.base_dir.starts_with(&root));
+    assert_eq!(paths.base_dir.file_name().unwrap(), ".frank_sherlock");
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add to `config.rs`:
+
+```rust
+/// Resolve paths; when `portable_root` is `Some`, place the data directory
+/// inside `<root>/.frank_sherlock/` so the catalog travels with the drive.
+pub fn resolve_paths_for_root(portable_root: Option<&Path>) -> AppResult<AppPaths> {
+    let base_dir = if let Some(root) = portable_root {
+        root.join(".frank_sherlock")
+    } else {
+        match env::var(DATA_DIR_ENV) {
+            Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
+            _ => default_base_dir()?,
+        }
+    };
+    build_paths(base_dir)
+}
+
+fn build_paths(base_dir: PathBuf) -> AppResult<AppPaths> {
+    let db_dir = base_dir.join("db");
+    let cache_dir = base_dir.join("cache");
+    Ok(AppPaths {
+        db_file: db_dir.join("index.sqlite"),
+        classification_cache_dir: cache_dir.join("classifications"),
+        thumbnails_dir: cache_dir.join("thumbnails"),
+        scans_dir: cache_dir.join("scans"),
+        surya_venv_dir: base_dir.join("surya_venv"),
+        tmp_dir: cache_dir.join("tmp"),
+        models_dir: base_dir.join("models"),
+        face_crops_dir: cache_dir.join("face_crops"),
+        db_dir,
+        cache_dir,
+        base_dir,
+    })
+}
+```
+
+Rewrite the existing `resolve_paths()` to `build_paths(base)` so both entry points share.
+
+- [ ] **Step 3: Persist the choice**
+
+In `user_config`, store `portable_root: Option<String>`. On startup `lib.rs` calls `resolve_paths_for_root(config.portable_root.as_deref().map(Path::new))`.
+
+- [ ] **Step 4: Add UI toggle**
+
+In the settings dialog, add a checkbox "Store catalog inside scanned root (portable)" + a path picker. On save, write config and prompt a restart.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat: portable mode stores catalog under <root>/.frank_sherlock"
+```
+
+### Task 1.8: Ignore `.frank_sherlock` during scan
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/scan.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `scan.rs`:
+
+```rust
+#[test]
+fn scan_skips_frank_sherlock_dir() {
+    // Arrange a root with .frank_sherlock/db/index.sqlite; walker must not enter.
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".frank_sherlock/db")).unwrap();
+    std::fs::write(dir.path().join(".frank_sherlock/db/index.sqlite"), b"x").unwrap();
+    std::fs::write(dir.path().join("photo.jpg"), b"ignored payload").unwrap();
+
+    let entries = walk_indexable(dir.path()).unwrap();
+    let names: Vec<_> = entries.iter().map(|p| p.file_name().unwrap().to_string_lossy().to_string()).collect();
+    assert!(names.contains(&"photo.jpg".to_string()));
+    assert!(!names.iter().any(|n| n == "index.sqlite"));
+}
+```
+
+- [ ] **Step 2: Add the filter**
+
+In the scan walker (`walkdir::WalkDir::new(...).into_iter().filter_entry(...)`), filter out any entry whose `file_name()` equals `".frank_sherlock"`. If `walk_indexable` is not an existing public helper, extract the walker into one for testability.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "fix(scan): skip .frank_sherlock portable catalog during walks"
+```
+
+### Task 1.9: End-to-end smoke via webapp-testing
+
+- [ ] **Step 1** — Use the `anthropic-skills:webapp-testing` skill to drive the dev app: create a root, scan a tiny dir, rename the dir, remap, confirm no rescans.
+- [ ] **Step 2** — Repeat with export → wipe `base_dir` → import → confirm results appear unchanged.
+- [ ] **Step 3** — Commit `docs/superpowers/plans/2026-04-20-phase1-smoke.md` with the scenario transcript.
+
+```bash
+git commit -am "docs: phase-1 portability smoke transcript"
+```
+
+---
+
+## Phase 2 — Schema Normalization
+
+**Why:** Phase 1 works but `remap_root` has to rewrite every row's `abs_path`. Normalize so `abs_path` is derived, not stored.
+
+**Approach:** Drop the column, expose it through a VIEW (`files_with_abs`) that joins `roots.root_path || '/' || files.rel_path`. All call sites that currently `SELECT abs_path FROM files` become `SELECT abs_path FROM files_with_abs`. All writers stop filling it.
+
+**Tasks:**
+
+- [ ] **2.1** Migration 12: `CREATE VIEW files_with_abs AS SELECT f.*, (r.root_path || '/' || f.rel_path) AS abs_path FROM files f JOIN roots r ON r.id = f.root_id`. On Windows use `REPLACE` to normalize separators or store `root_path` without trailing slash and let `rel_path` carry the separator.
+- [ ] **2.2** Audit every `SELECT ... abs_path ... FROM files` (`rg "abs_path" src-tauri/src/`) and rewrite to read from the view. Writers: remove `abs_path` from INSERTs and the UPSERT on conflict.
+- [ ] **2.3** Migration 13: `ALTER TABLE files DROP COLUMN abs_path` (SQLite ≥ 3.35).
+- [ ] **2.4** Rewrite `remap_root`: remove the files UPDATE, keep roots + scan_jobs updates only. Tests still pass because `abs_path` is now computed.
+- [ ] **2.5** Add `cargo test --lib` + `npm run test` green-run gate before commit.
+
+```bash
+git commit -am "refactor(db): make abs_path a derived view"
+```
+
+**Rollback plan:** migrations are append-only; if the view breaks anything, add Migration 14 that re-adds `abs_path` and a one-off `UPDATE files SET abs_path = r.root_path || '/' || f.rel_path` rebuild.
+
+---
+
+## Phase 3 — Watch Mode
+
+**Deliverables:** When enabled, the app watches each `root` via the `notify` crate. New/modified files are queued for classification without a full rescan.
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/watcher.rs`
+- Modify: `sherlock/desktop/src-tauri/Cargo.toml` (`notify = "6"`)
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs` (spawn watcher task)
+- Create: `sherlock/desktop/src/features/watcher/WatcherToggle.tsx`
+
+**Tasks:**
+
+- [ ] **3.1** Extract the single-file classify pipeline out of `scan.rs` into `pipeline::process_one(path)` callable from both scan and watcher. Preserve cache and move-detection semantics.
+- [ ] **3.2** Implement `watcher::start(roots, tx: Sender<PathBuf>, cancel: CancellationToken)`. Use `notify::RecommendedWatcher`, debounce via `notify-debouncer-full` 0.3+ to coalesce bursts within 1s.
+- [ ] **3.3** Spawn a Tokio task consuming the channel, calling `pipeline::process_one(path)`, emitting `scan-progress` events so the existing UI updates.
+- [ ] **3.4** UI: `WatcherToggle.tsx` with per-root on/off, backed by `user_config.watch = { rootId: bool }`. Persist, emit `watcher_configure_cmd`.
+- [ ] **3.5** Tests: integration test under `src-tauri/tests/watcher_integration.rs` that creates a tempdir, writes a JPEG, asserts the DB contains a matching `files` row within 5s. Mock Ollama via a local HTTP stub (pattern from `classify.rs` tests).
+- [ ] **3.6** Ignore `.frank_sherlock/` and any path matching the existing scan filters.
+
+```bash
+git commit -am "feat: filesystem watch mode with debounced classification"
+```
+
+---
+
+## Phase 4 — Priority Queue + Multi-Model
+
+### 4A — Priority queue
+
+**Problem:** current scan processes files in directory order. For a 100k-file NAS, brand-new photos from today sit at the end.
+
+**Tasks:**
+
+- [ ] **4A.1** Introduce `scan_queue` table: `(file_id, priority INT, enqueued_at INT)`; `priority` is `100 - log10(age_seconds + 1) * 10` clamped — newer files bubble up. Populate during Phase-1 discovery.
+- [ ] **4A.2** Replace the phase-2 loop with a heap pull: `SELECT file_id FROM scan_queue ORDER BY priority DESC, enqueued_at ASC LIMIT 1`.
+- [ ] **4A.3** Watcher (Phase 3) inserts with priority 200 (above any backfill).
+- [ ] **4A.4** Add `cargo test scan_queue_orders_recent_first`.
+
+### 4B — Multi-model profiles
+
+**Tasks:**
+
+- [ ] **4B.1** Extend `user_config.json` schema:
+  ```json
+  { "modelProfiles": { "fast": "moondream:latest", "thorough": "qwen2.5vl:7b" },
+    "activeProfile": "thorough" }
+  ```
+- [ ] **4B.2** `classify.rs` reads `active_profile` from state instead of the hard-coded constant. For `fast`, skip OCR + document enrichment (still cheap with moondream).
+- [ ] **4B.3** Add UI dropdown in the scan dialog: "Model: Fast / Thorough". Store last choice per root.
+- [ ] **4B.4** Test: launch classify with a fake HTTP stub, assert the model name in the outgoing request matches the active profile.
+
+```bash
+git commit -am "feat: priority queue + fast/thorough model profiles"
+```
+
+---
+
+## Phase 5 — Manual Corrections + Few-Shot
+
+**Goal:** let users override a bad classification and feed the correction back into the prompt as a few-shot example.
+
+**Tasks:**
+
+- [ ] **5.1** Migration 14: `CREATE TABLE file_overrides (file_id INTEGER PRIMARY KEY, media_type TEXT, description TEXT, tags TEXT, corrected_at INTEGER, FOREIGN KEY(file_id) REFERENCES files(id) ON DELETE CASCADE)`.
+- [ ] **5.2** Tauri commands: `override_classification_cmd(file_id, { mediaType?, description?, tags? })`, `clear_override_cmd(file_id)`.
+- [ ] **5.3** Query reads: join `file_overrides` and COALESCE overrides over the model output.
+- [ ] **5.4** UI: preview overlay gains "Edit classification" button → modal with media-type select + description textarea + tag chips.
+- [ ] **5.5** Few-shot: at classify time, pull up to 5 random overrides with the same media-type guess and inject them as "here are corrections from the user" examples before the instruction block in `classify.rs`.
+- [ ] **5.6** Add `cargo test classify_injects_user_corrections` using the HTTP stub to assert the prompt body contains the correction text.
+
+```bash
+git commit -am "feat: manual classification overrides with few-shot feedback"
+```
+
+---
+
+## Phase 6 — UI Polish
+
+### 6A — Dedup actions
+
+**Tasks:**
+
+- [ ] **6A.1** Add command `dedup_action_cmd(file_ids: Vec<i64>, action: "trash" | "hardlink_to_first")`. Use the `trash` crate for cross-platform recycle-bin moves. For hardlink, pick the oldest `mtime_ns` as the canonical target and `std::fs::hard_link` the others after deleting.
+- [ ] **6A.2** UI: the existing duplicates view gains a footer with two buttons. Guard destructive actions with a confirm dialog showing how many files are affected.
+- [ ] **6A.3** After success, mark the removed rows as `deleted_at = now` so FTS drops them.
+
+### 6B — EXIF panel
+
+**Tasks:**
+
+- [ ] **6B.1** `exif.rs` already extracts most fields; expose them via `get_file_exif_cmd(file_id) -> ExifView { date, gps, camera, lens, iso, shutter, aperture }`.
+- [ ] **6B.2** Preview overlay: collapsible "Details" panel on the right rail rendering the fields when present.
+- [ ] **6B.3** If `gps` is populated, render a small OpenStreetMap link (`https://www.openstreetmap.org/?mlat=…&mlon=…#map=14/…/…`).
+
+```bash
+git commit -am "feat(ui): dedup actions + EXIF panel"
+```
+
+---
+
+## Post-phase checklist
+
+- [ ] All `cargo test` + `npm run test` green on all three OS matrices.
+- [ ] CLAUDE.md updated with new commands, tables and config keys.
+- [ ] `releases/vNEXT.md` summarizes the phase-level features user-visibly.
+- [ ] Manual smoke: ingest a 100-file directory, rename it, remap, confirm zero reprocesses.
+
+```
+

--- a/docs/superpowers/plans/2026-04-20-phase1-smoke.md
+++ b/docs/superpowers/plans/2026-04-20-phase1-smoke.md
@@ -1,0 +1,140 @@
+# Phase 1 — Data Portability: Delivery Record & Smoke Recipe
+
+**Branch:** `feat/portability` (parent: `master` @ `f3fd8b7`)
+**Date:** 2026-04-20
+**Plan:** [2026-04-20-frank-sherlock-improvements.md](./2026-04-20-frank-sherlock-improvements.md) — Phase 1 only.
+
+---
+
+## Commits (9)
+
+| SHA | Message |
+|-----|---------|
+| `827a93d` | feat(db): add remap_root for drive-letter and path swaps |
+| `b1106a6` | fix(db): address review feedback on remap_root |
+| `ffd6322` | feat: expose remap_root_cmd to frontend |
+| `458f229` | feat(ui): remap root modal wired into sidebar context menu |
+| `79f9328` | feat(portability): zip-based catalog export |
+| `25d6dbf` | feat(portability): import catalog from zip with zip-slip defense |
+| `80f21de` | feat(ui): export and import catalog dialogs wired into sidebar tools |
+| `2d6d03b` | feat(portability): portable mode — catalog under <root>/.frank_sherlock |
+| `15f9348` | fix(scan): skip .frank_sherlock portable catalog during walks |
+
+## Automated coverage
+
+All nine tasks landed under TDD with code-review gating.
+
+**Rust backend (`cargo test --lib`)** — 347 passed / 0 failed (baseline 329 → +18).
+
+- `db::tests::remap_root_*` — 6 tests (happy path, collision rejection, prefix-only defense, scan_jobs counter, no-op shortcut, rollback on prefix mismatch).
+- `portability::export_tests::*` — 3 tests (happy path, missing cache dirs graceful, refuse overwrite).
+- `portability::import_tests::*` — 4 tests (happy path, refuse on existing catalog, zip-slip rejection, full roundtrip byte-equivalence).
+- `config::tests::resolve_paths_portable_*` — 3 tests (portable uses `<root>/.frank_sherlock`, precedence over `DATA_DIR_ENV`, None falls back to env).
+- `scan::tests::*frank_sherlock*` — 2 tests (helper unit + walker integration).
+
+**Frontend (`npm run test`)** — 312 passed / 0 failed (baseline 299 → +13).
+
+- `RemapRootModal.test.tsx` — 3 tests (happy path, error, disabled when equal).
+- `ExportCatalogModal.test.tsx` — 4 tests (cancel, success, error, open-folder).
+- `ImportCatalogModal.test.tsx` — 5 tests (confirm, cancel, re-pick, success, overwrite hint).
+- Existing `RootCard.test.tsx` / `Sidebar.test.tsx` touched for the new optional props.
+
+---
+
+## Manual smoke recipe
+
+The features below require a real Ollama + Windows/Linux/macOS window, so they are validated by a scripted manual walk. Run through once per release candidate.
+
+### Prerequisites
+
+```bash
+# From project root
+ollama serve   # separate terminal
+cd sherlock/desktop
+npm run tauri:dev
+```
+
+Have a scratch folder of ≥50 small images on drive `D:` (e.g. `D:\photo-test\`).
+
+---
+
+### Scenario A — remap after drive-letter change
+
+1. First launch → "Add folder" → pick `D:\photo-test\` → let classify finish.
+2. Close the app.
+3. Swap the drive letter via Disk Management (Windows) or by renaming the folder on Linux/macOS: `D:\photo-test` → `E:\photo-test` (or `/mnt/a` → `/mnt/b`).
+4. Launch Frank Sherlock. The root will appear with the old path and thumbnails broken.
+5. Right-click the root card in the sidebar → **Remap Path…**
+6. Input the new path (e.g. `E:\photo-test`), click **Remap**.
+7. Expect toast: "Remapped …" and the `files_updated` count ≥ the number of images.
+8. Expect thumbnails to load again without any rescan.
+9. Reopen the classified gallery — search queries still work (FTS unchanged).
+
+**Expected failure modes** (error paths to confirm):
+- Remap onto a path already registered as another root → `remap target already exists as a root: …`.
+- Remap typo that doesn't prefix any existing `abs_path` → `remap rewrote 0 of N file paths; abs_path prefix mismatch — aborting` (transaction rolled back; try again with correct path).
+
+---
+
+### Scenario B — export → wipe → import roundtrip
+
+1. With a non-empty catalog, Sidebar → Tools → **Export Catalog…**
+2. Native save dialog → save to `D:\bundle.zip`.
+3. Expect success UI with entries count and byte size, plus **Open folder** button that opens the containing directory.
+4. Quit the app.
+5. Wipe the default data dir:
+   - Windows: `rmdir /S /Q %LOCALAPPDATA%\frank_sherlock`
+   - Linux: `rm -rf ~/.local/share/frank_sherlock`
+   - macOS: `rm -rf ~/Library/Application\ Support/frank_sherlock`
+6. Launch the app — it should start fresh (no roots, no thumbnails).
+7. Sidebar → Tools → **Import Catalog…** → click "Choose file…" → pick `D:\bundle.zip`.
+8. Expect success UI with the same entries count, then the hint "Restart recommended".
+9. Restart the app. Verify:
+   - All roots reappear in the sidebar with correct counts.
+   - Thumbnails render immediately (no reclassify).
+   - Search queries return the same results as before export.
+
+**Expected failure modes:**
+- Import into a directory that already contains `db/index.sqlite` → error "refusing to overwrite existing catalog" with a tip to export/move first.
+- Import a zip containing a path-traversal entry → rejected with `"zip contains unsafe path: …"`. (Can't easily reproduce manually; fully covered by `import_rejects_path_traversal` Rust test.)
+
+---
+
+### Scenario C — portable mode (backend only; UI deferred)
+
+1. Quit the app.
+2. Edit `~/.config/frank_sherlock/config.json` (or the platform equivalent) and set:
+   ```json
+   { "portableRoot": "D:\\photo-test" }
+   ```
+3. Relaunch.
+4. Expect the app to create `D:\photo-test\.frank_sherlock\db\index.sqlite` and `…\cache\thumbnails\` on first write. All new indexing data lives under the portable root.
+5. Scan `D:\photo-test` and confirm the scanner does **not** index anything inside `.frank_sherlock/` (i.e. the thumbnails and db are not themselves classified).
+6. Move the drive to another machine; set `portableRoot` on that machine to the new mount point.
+7. The catalog is visible without rescan.
+
+**Clearing portable mode:** remove the `portableRoot` field from `config.json` (or set it to `""`) and restart. Existing portable data stays on the drive; the app returns to the default location.
+
+**Known rough edges (acceptable for MVP):**
+- No UI toggle yet — power-user JSON edit only. UI toggle was intentionally scoped out of Phase 1.
+- Changing `portableRoot` does not migrate existing data; it only redirects the next launch.
+- `set_portable_root_cmd` validates the directory exists but is not atomic against concurrent writes to `user_config`.
+
+---
+
+## Known follow-ups (non-blocking for Phase 1 merge)
+
+Captured from the code-review cycles, deferred to later phases:
+
+1. **Phase 2 refactor** (already planned) — make `abs_path` a derived view over `roots.root_path || '/' || files.rel_path`. Eliminates the prefix-rewrite logic in `remap_root`.
+2. Export/import: stream large files via `std::io::copy` instead of `Vec::with_capacity(zip_file.size())` to defend against declared-size DoS on imported zips. Low priority — import is a user-initiated action with a user-provided file.
+3. Export/import: write-to-temp-then-rename for crash-safe atomicity.
+4. Wrap export + import Tauri commands in `tauri::async_runtime::spawn_blocking` for large catalogs to avoid blocking the main runtime thread.
+5. Portable mode UI: checkbox + path picker in a Settings modal (the Help modal is search-only, so a dedicated Settings modal is the right place).
+6. `AppError::Io` / `AppError::Conflict` variants — several paths currently funnel through `AppError::Config` for I/O + data-conflict errors. Semantic cleanup opportunity.
+
+---
+
+## Verdict
+
+Phase 1 delivers its promise: the user can change drive letters, migrate machines, and keep their catalog portable without reprocessing hours of Ollama classification. All 9 tasks passed both spec-compliance and code-quality review. Automated suites +31 tests, both green. Manual smoke recipe above is the last gate before merging `feat/portability` back to `master`.

--- a/docs/superpowers/plans/2026-04-21-auto-organize-and-findability.md
+++ b/docs/superpowers/plans/2026-04-21-auto-organize-and-findability.md
@@ -1,0 +1,849 @@
+# Auto-Organize & Findability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 21 features across six phases that turn the catalog into a navigable memory — auto-organizing media from existing EXIF/dHash/face data, and adding visual search tools so the user finds anything in ≤3 clicks.
+
+**Architecture:** Every phase reuses data already in the DB (EXIF via `exif.rs`, dHash via `similarity.rs`, face embeddings via `face.rs`, descriptions from the Ollama pipeline). No new ML models. Phase 1 lands the SQL-only wins; Phase 2 upgrades the search bar; Phases 3-6 layer clustering, map/color, rules, and ambient surfaces on top.
+
+**Tech stack:** Rust (rusqlite migrations, `image` + `imageproc` for blur detection, `rqrr` for QR), React + TS (Vitest), SQLite FTS5, Leaflet or MapLibre GL (Phase 4).
+
+**Phase map:**
+
+| # | Name | Features | Est. |
+|---|---|---|---|
+| 1 | EXIF-only quick wins | camera/lens filter, time-of-day filter, tag autocomplete | 1-2d |
+| 2 | Search builder & timeline | visual query chips, tag autocomplete wiring, timeline heatmap | 2-3d |
+| 3 | Auto-clustering | events, trips, burst collapse, blur detect, year-in-review, dedup policies | 4-5d |
+| 4 | Map, color, content | color palette, offline map + nearby, QR/barcode | 3-4d |
+| 5 | Auto-tagging & smart albums | path-pattern rules, face smart albums, album tag inheritance, selfie/group | 2-3d |
+| 6 | Ambient surfaces | saved-search alerts, ambient similar sidebar | 1-2d |
+
+---
+
+## Phase 1 — EXIF-only quick wins
+
+**Problem:** `exif.rs` already extracts camera model, lens model, ISO, shutter, aperture, and datetime into the DB (Migration 1 stored `location_text`; we'll need a new migration for the camera/lens columns if they're not yet persisted — check first). All of this is already indexed but no UI surfaces it. The user can't answer "which photos are from my iPhone 14?" in the current app.
+
+**Deliverables:** Three new filter inputs wired into the existing search, plus a tag-autocomplete hook the Phase 2 chip builder will reuse.
+
+### Task 1.1: Persist camera/lens columns (if missing)
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/db.rs` (append migration)
+- Modify: `sherlock/desktop/src-tauri/src/exif.rs` (fill the columns during extraction)
+- Modify: `sherlock/desktop/src-tauri/src/scan.rs` (pass the values through to `upsert_file`)
+
+- [ ] **Step 1: Verify the current schema**
+
+Run from the worktree:
+
+```
+cd sherlock/desktop/src-tauri && grep -n "camera_model\|lens_model\|iso\|shutter_speed\|aperture" src/db.rs src/exif.rs
+```
+
+If the columns already exist (some projects land them silently), skip to Task 1.2. If not, proceed.
+
+- [ ] **Step 2: Write the failing migration test**
+
+Append to `#[cfg(test)] mod tests` in `db.rs`:
+
+```rust
+#[test]
+fn migration_adds_camera_and_lens_columns() {
+    use tempfile::tempdir;
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+    init_database(&db_path).unwrap();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut stmt = conn.prepare("PRAGMA table_info(files)").unwrap();
+    let cols: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+
+    for required in ["camera_model", "lens_model", "iso", "shutter_speed", "aperture", "time_of_day"] {
+        assert!(cols.iter().any(|c| c == required), "missing column {required}, got {cols:?}");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```
+cd sherlock/desktop/src-tauri && cargo test migration_adds_camera --lib
+```
+
+Expected: FAIL on missing columns.
+
+- [ ] **Step 4: Append the migration**
+
+Find the bottom of the `Migrations::new(vec![...])` list in `run_migrations()` and append:
+
+```rust
+// Migration 12: camera/lens/EXIF detail columns for Phase 1 quick filters.
+M::up(
+    "ALTER TABLE files ADD COLUMN camera_model TEXT NOT NULL DEFAULT '';
+     ALTER TABLE files ADD COLUMN lens_model TEXT NOT NULL DEFAULT '';
+     ALTER TABLE files ADD COLUMN iso INTEGER;
+     ALTER TABLE files ADD COLUMN shutter_speed REAL;
+     ALTER TABLE files ADD COLUMN aperture REAL;
+     ALTER TABLE files ADD COLUMN time_of_day TEXT NOT NULL DEFAULT '';
+     CREATE INDEX IF NOT EXISTS idx_files_camera_model ON files(camera_model);
+     CREATE INDEX IF NOT EXISTS idx_files_time_of_day ON files(time_of_day);"
+),
+```
+
+(If the migration count in the existing list is not 12 when you add this, adjust the number in the comment — `rusqlite_migration` identifies migrations by position, not by the comment.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cargo test migration_adds_camera --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add sherlock/desktop/src-tauri/src/db.rs
+git commit -m "feat(db): add camera/lens/iso/shutter/aperture/time_of_day columns"
+```
+
+### Task 1.2: Populate the columns from EXIF
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/exif.rs`
+- Modify: `sherlock/desktop/src-tauri/src/db.rs` (the `upsert_file` writer — add the new fields to the `FileRecord`/INSERT)
+- Modify: `sherlock/desktop/src-tauri/src/scan.rs` (pass the values through)
+
+- [ ] **Step 1: Write the failing extraction test**
+
+Append to `#[cfg(test)] mod tests` in `exif.rs`:
+
+```rust
+#[test]
+fn extract_exif_fills_camera_lens_iso_aperture_time_of_day() {
+    // Use a fixture JPEG that ships with the project or embed one here via include_bytes!.
+    let bytes = include_bytes!("../tests/fixtures/canon_5d_sample.jpg");
+    // If that fixture doesn't exist, generate a tiny in-memory JPEG with known EXIF.
+    let meta = extract_exif_from_bytes(bytes).unwrap();
+    assert!(!meta.camera_model.is_empty());
+    assert!(meta.iso.is_some());
+    assert!(matches!(meta.time_of_day.as_str(),
+        "night" | "dawn" | "morning" | "noon" | "afternoon" | "evening"));
+}
+```
+
+If no suitable fixture exists, build an inline test using a synthesized JPEG + known EXIF via the `kamadak-exif` crate (already a dep). The key assertion: `time_of_day` is derived from `DateTimeOriginal` hour.
+
+- [ ] **Step 2: Run to confirm failure**
+
+```
+cargo test extract_exif_fills --lib
+```
+
+Expected: FAIL (fields missing or all empty).
+
+- [ ] **Step 3: Extend the extractor**
+
+In `exif.rs`, find the `ExifMetadata` struct (or equivalent). Add fields:
+
+```rust
+pub struct ExifMetadata {
+    // ... existing fields ...
+    pub camera_model: String,
+    pub lens_model: String,
+    pub iso: Option<u32>,
+    pub shutter_speed: Option<f64>,
+    pub aperture: Option<f64>,
+    pub time_of_day: String,
+}
+```
+
+In the extractor function, read the EXIF tags:
+
+```rust
+let camera_model = reader
+    .get_field(Tag::Model, In::PRIMARY)
+    .and_then(|f| f.display_value().to_string().trim().trim_matches('"').to_string().into())
+    .unwrap_or_default();
+
+let lens_model = reader
+    .get_field(Tag::LensModel, In::PRIMARY)
+    .map(|f| f.display_value().to_string().trim().trim_matches('"').to_string())
+    .unwrap_or_default();
+
+let iso = reader
+    .get_field(Tag::PhotographicSensitivity, In::PRIMARY)
+    .and_then(|f| f.value.get_uint(0));
+
+let shutter_speed = reader
+    .get_field(Tag::ExposureTime, In::PRIMARY)
+    .and_then(|f| match &f.value {
+        exif::Value::Rational(v) if !v.is_empty() => Some(v[0].to_f64()),
+        _ => None,
+    });
+
+let aperture = reader
+    .get_field(Tag::FNumber, In::PRIMARY)
+    .and_then(|f| match &f.value {
+        exif::Value::Rational(v) if !v.is_empty() => Some(v[0].to_f64()),
+        _ => None,
+    });
+
+let time_of_day = datetime_original
+    .map(|dt| classify_time_of_day(dt.hour()))
+    .unwrap_or_default();
+```
+
+Add the helper at module scope:
+
+```rust
+fn classify_time_of_day(hour: u32) -> String {
+    match hour {
+        0..=4 => "night",
+        5..=7 => "dawn",
+        8..=11 => "morning",
+        12..=13 => "noon",
+        14..=17 => "afternoon",
+        18..=20 => "evening",
+        _ => "night",
+    }
+    .to_string()
+}
+```
+
+- [ ] **Step 4: Thread the values through the writer**
+
+In `db.rs`, find `FileRecord` (or whatever struct `upsert_file` takes) and add the six new fields, then update the INSERT + UPSERT to include them. If the struct has a builder, add setters; if it's a plain struct, add the fields with defaults.
+
+In `scan.rs`, wherever `FileRecord` is constructed for a scanned file, populate the new fields from the `ExifMetadata` returned by `extract_exif`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```
+cargo test extract_exif_fills --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add sherlock/desktop/src-tauri/src/exif.rs sherlock/desktop/src-tauri/src/db.rs sherlock/desktop/src-tauri/src/scan.rs
+git commit -m "feat(exif): extract camera/lens/iso/shutter/aperture/time_of_day"
+```
+
+### Task 1.3: `list_cameras` + `list_lenses` Tauri commands
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/filters.rs`
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs` (module + handler registration)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `filters.rs`:
+
+```rust
+//! Aggregation queries that feed the search-filter UI.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterOption {
+    pub value: String,
+    pub count: i64,
+}
+
+pub fn list_cameras(db_path: &Path) -> AppResult<Vec<FilterOption>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT camera_model, COUNT(*) AS c FROM files
+         WHERE deleted_at IS NULL AND camera_model != ''
+         GROUP BY camera_model ORDER BY c DESC, camera_model ASC",
+    )?;
+    let rows = stmt.query_map([], |r| Ok(FilterOption { value: r.get(0)?, count: r.get(1)? }))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+pub fn list_lenses(db_path: &Path) -> AppResult<Vec<FilterOption>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT lens_model, COUNT(*) AS c FROM files
+         WHERE deleted_at IS NULL AND lens_model != ''
+         GROUP BY lens_model ORDER BY c DESC, lens_model ASC",
+    )?;
+    let rows = stmt.query_map([], |r| Ok(FilterOption { value: r.get(0)?, count: r.get(1)? }))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+#[tauri::command]
+pub async fn list_cameras_cmd(state: tauri::State<'_, crate::AppState>) -> Result<Vec<FilterOption>, String> {
+    list_cameras(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn list_lenses_cmd(state: tauri::State<'_, crate::AppState>) -> Result<Vec<FilterOption>, String> {
+    list_lenses(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn seed(conn: &Connection, root_id: i64, filename: &str, camera: &str, lens: &str) {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at, camera_model, lens_model)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, ?5, 0, ?6, ?7)",
+            rusqlite::params![root_id, filename, filename, format!("D:\\P\\{filename}"),
+                              format!("fp-{filename}"), camera, lens],
+        ).unwrap();
+    }
+
+    #[test]
+    fn list_cameras_groups_and_counts_descending() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "D:\\P").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        seed(&conn, root, "a.jpg", "Canon EOS R5", "RF 24-70mm");
+        seed(&conn, root, "b.jpg", "Canon EOS R5", "RF 24-70mm");
+        seed(&conn, root, "c.jpg", "iPhone 14 Pro", "");
+        drop(conn);
+
+        let out = list_cameras(&db).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].value, "Canon EOS R5");
+        assert_eq!(out[0].count, 2);
+        assert_eq!(out[1].value, "iPhone 14 Pro");
+    }
+
+    #[test]
+    fn list_lenses_skips_empty() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "D:\\P").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        seed(&conn, root, "a.jpg", "", "50mm f/1.8");
+        seed(&conn, root, "b.jpg", "", "");
+        drop(conn);
+
+        let out = list_lenses(&db).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].value, "50mm f/1.8");
+    }
+}
+```
+
+- [ ] **Step 2: Register the module + handlers**
+
+In `lib.rs`: `mod filters;` and add `filters::list_cameras_cmd, filters::list_lenses_cmd,` to the `generate_handler!` list.
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test filters --lib -- --test-threads=1
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -am "feat(filters): list_cameras and list_lenses aggregation queries"
+```
+
+### Task 1.4: Thread camera/lens/time_of_day into search
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/query_parser.rs` (add tokens `camera:`, `lens:`, `time:`)
+- Modify: the search query builder (grep for `query_parser` callers in `lib.rs` or `db.rs` — find where `media_type` is applied as a WHERE clause, add parallel clauses).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `query_parser.rs` tests:
+
+```rust
+#[test]
+fn parses_camera_and_lens_and_time_tokens() {
+    let parsed = parse_query(r#"beach camera:"iPhone 14 Pro" lens:50mm time:evening"#);
+    assert_eq!(parsed.camera_model.as_deref(), Some("iPhone 14 Pro"));
+    assert_eq!(parsed.lens_model.as_deref(), Some("50mm"));
+    assert_eq!(parsed.time_of_day.as_deref(), Some("evening"));
+    assert_eq!(parsed.free_text.trim(), "beach");
+}
+```
+
+- [ ] **Step 2: Extend `ParsedQuery` + parser**
+
+Add the three `Option<String>` fields to `ParsedQuery`. In the parser loop, handle tokens matching `camera:`, `lens:`, `time:` (with quoted-string support — follow whatever pattern `subdir:` already uses).
+
+- [ ] **Step 3: Thread clauses into the SQL builder**
+
+Wherever the parsed query's `media_type` is applied (search for `ParsedQuery` usage), add `AND camera_model = ?` / `AND lens_model = ?` / `AND time_of_day = ?` clauses when the fields are `Some(_)`.
+
+- [ ] **Step 4: Run parser test + search test**
+
+```
+cargo test query_parser --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(search): camera:/lens:/time: query tokens"
+```
+
+### Task 1.5: Tag autocomplete backend
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/autocomplete.rs`
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `autocomplete.rs`:
+
+```rust
+//! Autocomplete suggestions for the search bar — pulls from canonical_mentions,
+//! camera_model, lens_model, and people.name. Lowercased + deduped + ranked by count.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Suggestion {
+    pub label: String,
+    pub kind: String,      // "person" | "camera" | "lens" | "mention"
+    pub count: i64,
+}
+
+pub fn suggest(db_path: &Path, prefix: &str, limit: usize) -> AppResult<Vec<Suggestion>> {
+    let needle = prefix.trim().to_lowercase();
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+    let pattern = format!("{needle}%");
+    let conn = open_conn(db_path)?;
+
+    let mut out: Vec<Suggestion> = Vec::new();
+
+    // People.
+    let mut stmt = conn.prepare(
+        "SELECT name, (SELECT COUNT(*) FROM face_detections WHERE person_id = p.id) AS c
+         FROM people p
+         WHERE LOWER(name) LIKE ?1
+         ORDER BY c DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "person".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row { out.push(s); }
+    }
+
+    // Cameras.
+    let mut stmt = conn.prepare(
+        "SELECT camera_model, COUNT(*) FROM files
+         WHERE deleted_at IS NULL AND camera_model != '' AND LOWER(camera_model) LIKE ?1
+         GROUP BY camera_model ORDER BY COUNT(*) DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "camera".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row { out.push(s); }
+    }
+
+    // Lenses.
+    let mut stmt = conn.prepare(
+        "SELECT lens_model, COUNT(*) FROM files
+         WHERE deleted_at IS NULL AND lens_model != '' AND LOWER(lens_model) LIKE ?1
+         GROUP BY lens_model ORDER BY COUNT(*) DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "lens".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row { out.push(s); }
+    }
+
+    // Canonical mentions (split on commas, filter by prefix).
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT canonical_mentions FROM files
+         WHERE deleted_at IS NULL AND canonical_mentions != ''",
+    )?;
+    let rows: Vec<String> = stmt.query_map([], |r| r.get::<_, String>(0))?
+        .filter_map(Result::ok).collect();
+    let mut mention_counts: std::collections::HashMap<String, i64> = Default::default();
+    for row in rows {
+        for token in row.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+            if token.to_lowercase().starts_with(&needle) {
+                *mention_counts.entry(token.to_lowercase()).or_default() += 1;
+            }
+        }
+    }
+    let mut mentions: Vec<(String, i64)> = mention_counts.into_iter().collect();
+    mentions.sort_by(|a, b| b.1.cmp(&a.1));
+    for (label, count) in mentions.into_iter().take(limit) {
+        out.push(Suggestion { label, kind: "mention".into(), count });
+    }
+
+    out.sort_by(|a, b| b.count.cmp(&a.count));
+    out.truncate(limit);
+    Ok(out)
+}
+
+#[tauri::command]
+pub async fn suggest_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    prefix: String,
+    limit: usize,
+) -> Result<Vec<Suggestion>, String> {
+    suggest(&state.paths.db_file, &prefix, limit).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    #[test]
+    fn suggest_matches_people_cameras_and_mentions() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "D:\\P").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        conn.execute(
+            "INSERT INTO people (name, created_at, updated_at) VALUES ('Alice', 0, 0)",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at, camera_model, canonical_mentions)
+             VALUES (?1, 'a.jpg', 'a.jpg', 'D:\\P\\a.jpg', 0, 0, 'fp1', 0, 'Alpha 7', 'Alice, Bob')",
+            rusqlite::params![root],
+        ).unwrap();
+        drop(conn);
+
+        let out = suggest(&db, "al", 10).unwrap();
+        let labels: Vec<String> = out.iter().map(|s| s.label.clone()).collect();
+        assert!(labels.iter().any(|l| l == "Alice"));
+        assert!(labels.iter().any(|l| l == "Alpha 7"));
+        assert!(labels.iter().any(|l| l == "alice"));
+    }
+
+    #[test]
+    fn suggest_empty_prefix_returns_empty() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let out = suggest(&db, "   ", 10).unwrap();
+        assert!(out.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Register + run tests**
+
+In `lib.rs`: `mod autocomplete;` and `autocomplete::suggest_cmd,` in the handler list.
+
+```
+cargo test autocomplete --lib -- --test-threads=1
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -am "feat(autocomplete): suggest people/cameras/lenses/mentions by prefix"
+```
+
+### Task 1.6: Wire `time:`/`camera:`/`lens:` into help modal and release note
+
+**Files:**
+- Modify: `sherlock/desktop/src/components/modals/HelpModal.tsx`
+- Modify or create: `releases/v0.11.0.md`
+
+- [ ] **Step 1: Add help entries**
+
+Add new `<div className="help-section">` blocks to `HelpModal.tsx` after the existing "Media types" section:
+
+```tsx
+<div className="help-section">
+  <h4>Camera / lens</h4>
+  <div className="help-examples">
+    <code>camera:"iPhone 14 Pro"</code>
+    <code>lens:50mm</code>
+  </div>
+</div>
+<div className="help-section">
+  <h4>Time of day</h4>
+  <div className="help-examples">
+    <code>time:evening</code>
+    <code>time:night</code>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Release note**
+
+Create `releases/v0.11.0.md` with a summary of the Phase 1 deliverables.
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -am "docs: v0.11.0 release notes + help entries for new search tokens"
+```
+
+### Task 1.7: Backfill existing catalogs
+
+**Files:**
+- Modify: `sherlock/desktop/src-tauri/src/lib.rs` (startup hook)
+
+- [ ] **Step 1: Add `backfill_exif_extras` migration hook**
+
+Existing rows created before Migration 12 have empty `camera_model`/etc. Run a one-shot backfill after startup that re-extracts EXIF for files where `camera_model = ''` AND the file still exists. Limit to 200 files per startup batch to avoid stalls.
+
+```rust
+fn backfill_exif_extras(db_path: &Path) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, abs_path FROM files
+         WHERE deleted_at IS NULL AND camera_model = '' AND lens_model = ''
+         ORDER BY id DESC LIMIT 200",
+    )?;
+    let rows: Vec<(i64, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .filter_map(Result::ok)
+        .collect();
+    for (id, path) in rows {
+        if let Ok(meta) = crate::exif::extract_exif(std::path::Path::new(&path)) {
+            conn.execute(
+                "UPDATE files SET camera_model = ?1, lens_model = ?2, iso = ?3,
+                                   shutter_speed = ?4, aperture = ?5, time_of_day = ?6
+                 WHERE id = ?7",
+                rusqlite::params![meta.camera_model, meta.lens_model, meta.iso,
+                                  meta.shutter_speed, meta.aperture, meta.time_of_day, id],
+            )?;
+        }
+    }
+    Ok(())
+}
+```
+
+Call it from `run()` in `lib.rs` after `recover_incomplete_scan_jobs`.
+
+- [ ] **Step 2: Commit**
+
+```
+git commit -am "feat(exif): incremental backfill of camera/lens/time_of_day on startup"
+```
+
+---
+
+## Phase 2 — Search builder & timeline
+
+**Deliverables:** Chip-based search input + tag autocomplete + timeline density heatmap on the grid.
+
+**Files:**
+- Create: `sherlock/desktop/src/components/Search/ChipSearchBar.tsx`
+- Create: `sherlock/desktop/src/components/Search/TagAutocomplete.tsx`
+- Create: `sherlock/desktop/src/components/Content/TimelineHeatmap.tsx`
+- Modify: `sherlock/desktop/src/App.tsx` (replace the existing search input wiring)
+- Modify: `sherlock/desktop/src/hooks/useSearch.ts`
+
+### Task 2.1: `ChipSearchBar`
+
+Component UX: user types free text; pressing `:` exposes a popup menu listing available facets (media, camera, lens, time, person, date, subdir, album). Selecting one converts the pending token into a chip with a value input. Chips render to the left of the free-text input. Delete via `×` on chip or backspace on empty input.
+
+- [ ] **2.1.1** Write the component test covering: typing free text, typing `media:photo`, deleting chips, serializing back to query string on submit.
+- [ ] **2.1.2** Implement `ChipSearchBar.tsx` with `useReducer` for chip state, emits `onQueryChange(query: string)` parents bind to `useSearch`.
+- [ ] **2.1.3** Style chips via new `ChipSearchBar.css` with monochrome pills + colored dot per facet kind.
+- [ ] **2.1.4** Wire into App.tsx, replacing the plain `<input>` the current search uses.
+
+### Task 2.2: `TagAutocomplete`
+
+- [ ] **2.2.1** Dropdown component that binds to `suggest_cmd`. Debounced 150ms. Keyboard nav (↑/↓/Enter). Kind icon per suggestion (`person`/`camera`/`lens`/`mention`).
+- [ ] **2.2.2** Integrate into `ChipSearchBar` so that while a chip value is being typed, the dropdown shows.
+- [ ] **2.2.3** Tests: debounce behavior, keyboard nav, kind rendering.
+
+### Task 2.3: `TimelineHeatmap`
+
+- [ ] **2.3.1** Aggregate SQL: `SELECT strftime('%Y-%m', datetime(mtime_ns/1e9, 'unixepoch')) AS bucket, COUNT(*) FROM files WHERE deleted_at IS NULL GROUP BY bucket`. Expose as `list_timeline_buckets_cmd`.
+- [ ] **2.3.2** Sidebar component renders a vertical bar (one row per month) with width ∝ count, color gradient. Clicking a month sets `from:/to:` on the query.
+- [ ] **2.3.3** Test: correct month labels, click dispatches the right query.
+
+### Task 2.4: Release + docs
+
+- [ ] **2.4.1** `releases/v0.12.0.md` + CLAUDE.md entry for `ChipSearchBar`, `TagAutocomplete`, `TimelineHeatmap`, `autocomplete.rs`, `filters.rs`.
+
+---
+
+## Phase 3 — Auto-clustering
+
+**Deliverables:** Six auto-organization wins that use existing EXIF + dHash + file size — zero new ML.
+
+### Task 3.1: Event clusters (GPS + date window)
+
+**Files:**
+- Create: `sherlock/desktop/src-tauri/src/clustering.rs`
+- Modify: `sherlock/desktop/src-tauri/src/db.rs` (new table `events`)
+
+Approach: DBSCAN-lite on `(gps_lat, gps_lon, datetime)` with two ε (spatial 500m, temporal 6h). Every cluster becomes a row in a new `events` table with auto-generated name (`{city-from-location_text} — {date}` heuristic); user can rename.
+
+**Tasks:**
+- [ ] **3.1.1** Migration 13: `CREATE TABLE events (id INTEGER PK, name TEXT, started_at INTEGER, ended_at INTEGER, centroid_lat REAL, centroid_lon REAL, cover_file_id INTEGER)` + `event_files (event_id, file_id, UNIQUE)`.
+- [ ] **3.1.2** `fn cluster_events(db_path) -> AppResult<Vec<EventSummary>>` runs DBSCAN-lite over files with non-null GPS + datetime. Idempotent: re-running merges into existing rows by centroid proximity, doesn't duplicate.
+- [ ] **3.1.3** Tauri command `recompute_events_cmd`. Returns the number of events created/updated. Meant to run manually from a menu button or automatically after a scan.
+- [ ] **3.1.4** Tests: 3 files within window → 1 event; 3 files split across 2 days → 2 events; GPS-less files ignored.
+
+### Task 3.2: Trip detector
+
+Similar to 3.1 but bigger scale. An "event" is a single photo session; a "trip" is a set of events outside the user's "home cluster" (defined as the highest-density 50 km² region). Add `trip_id` column to events.
+
+- [ ] **3.2.1** Compute home cluster on demand (cheap SQL over events.centroid_lat/lon).
+- [ ] **3.2.2** Events whose centroid is >50 km from home and within 7 days of a predecessor are merged into a trip.
+- [ ] **3.2.3** `list_trips_cmd` returns `Vec<TripSummary { id, name_guess, started_at, ended_at, event_count, cover_file_id }>`.
+- [ ] **3.2.4** UI: sidebar "Trips" section with collapsible list.
+
+### Task 3.3: Burst collapse
+
+- [ ] **3.3.1** `find_bursts(db_path)` detects groups of ≥3 files with same `camera_model` and mtime within 2s. Returns `Vec<Burst { cover_file_id, member_ids }>`.
+- [ ] **3.3.2** UI: in the grid, bursts render as a single tile with "+N" badge; expanding shows the full burst inline.
+- [ ] **3.3.3** Selection logic: selecting the cover selects the whole burst; user can "Keep cover, trash rest" in one click.
+
+### Task 3.4: Blur detection
+
+- [ ] **3.4.1** Migration 14: `ALTER TABLE files ADD COLUMN blur_score REAL`. Nullable.
+- [ ] **3.4.2** During thumbnail generation, compute Laplacian variance via `imageproc::gradients::laplacian` on a 512px downscale. Store the variance. Low variance = blurry.
+- [ ] **3.4.3** Add `blur:true` / `blur:false` query token and a "Hide blurry" toggle in the toolbar.
+- [ ] **3.4.4** Tests: a crisp checkerboard yields high variance, a uniform blur yields low.
+
+### Task 3.5: Year-in-review generator
+
+- [ ] **3.5.1** `generate_year_review(db_path, year)` — picks top-12 photos (one per month where possible), prioritized by confidence × (1 + faces_count/5), excluding duplicates. Creates a new album named `Year in Review — {year}`.
+- [ ] **3.5.2** Tauri command + a button in the Albums sidebar: "Generate year in review".
+- [ ] **3.5.3** Tests: ensure one photo per month when the year is dense, gaps allowed when sparse.
+
+### Task 3.6: Dedup policies
+
+- [ ] **3.6.1** Migration 15: `CREATE TABLE dedup_policy (id INTEGER PK, strategy TEXT CHECK(strategy IN ('keep_largest','keep_oldest','keep_in_album')))`.
+- [ ] **3.6.2** After each scan, if a policy is set, auto-apply it to newly discovered exact duplicates (soft-delete the losers). Keep a small audit trail.
+- [ ] **3.6.3** UI: dropdown in the Duplicates view to set the active policy.
+- [ ] **3.6.4** Tests: each strategy picks the right winner.
+
+### Task 3.7: Release + docs
+
+- [ ] **3.7.1** `releases/v0.13.0.md` + CLAUDE.md entries.
+
+---
+
+## Phase 4 — Map, color, content
+
+### Task 4.1: Color palette search
+
+- [ ] **4.1.1** Migration 16: `ALTER TABLE files ADD COLUMN dominant_color INTEGER` (packed `0xRRGGBB`).
+- [ ] **4.1.2** During thumbnail gen, k-means (k=3) on a 64×64 downscale of each image; store the cluster with the largest weight. Use `imageproc::region_labelling` or a hand-rolled 3-centroid Lloyd iteration (50 iters max).
+- [ ] **4.1.3** Query token: `color:orange` / `color:green` with a name → HSV-range table (~12 named colors).
+- [ ] **4.1.4** UI: color-swatch row in the toolbar; click swatches to add the token.
+
+### Task 4.2: Offline map view
+
+- [ ] **4.2.1** Add `maplibre-gl` (MIT) to the frontend. Store tiles in `<base_dir>/cache/osm_tiles/`. First-fetch downloads tiles around viewed photos on demand.
+- [ ] **4.2.2** New view mode `MapView` (parallel to `DuplicatesView`/`FacesView`) that renders pins for every file with GPS. Clustering at zoom-out; on click, pans to the photo grid filtered to that region.
+- [ ] **4.2.3** Respect user's tile-download budget (default: only download tiles for regions with ≥5 photos). Offline-first: if a tile isn't cached and we're offline, show a gray tile.
+
+### Task 4.3: "Nearby" on a selected photo
+
+- [ ] **4.3.1** Right-click a photo with GPS → "Find nearby" → runs `SELECT WHERE gps_lat BETWEEN ?-delta AND ?+delta AND gps_lon BETWEEN ... ORDER BY haversine(...) LIMIT 50`.
+- [ ] **4.3.2** Results open in a grid, same UI surface the existing search uses.
+- [ ] **4.3.3** Context menu entry added only when the file has GPS (extend the existing menu logic in `ContextMenu.tsx`).
+
+### Task 4.4: QR/barcode decode
+
+- [ ] **4.4.1** Add `rqrr` (MIT) to Cargo deps.
+- [ ] **4.4.2** Migration 17: `ALTER TABLE files ADD COLUMN qr_codes TEXT NOT NULL DEFAULT ''` (comma-joined decoded payloads).
+- [ ] **4.4.3** During classification (optional stage, after OCR), run QR decoder on the full-res image; save decoded strings. Make this part of the FTS index so the user can `qr:wifi` or free-text-search for `"MECARD:"`.
+- [ ] **4.4.4** UI: properties panel shows QR decoded text with a "Copy" button.
+
+### Task 4.5: Release + docs
+
+- [ ] **4.5.1** `releases/v0.14.0.md` + CLAUDE.md entry for `clustering.rs`, `MapView`, QR pipeline.
+
+---
+
+## Phase 5 — Auto-tagging & smart albums
+
+### Task 5.1: Path-pattern auto-tag rules
+
+- [ ] **5.1.1** Migration 18: `CREATE TABLE tag_rules (id, pattern TEXT, tag TEXT, enabled INTEGER)`.
+- [ ] **5.1.2** At scan time, for each new file compute `rel_path`; for each enabled rule, compiled-regex match yields a tag stored in `canonical_mentions`.
+- [ ] **5.1.3** UI: simple rule editor modal — list + add/edit/delete — with live preview of which files match.
+
+### Task 5.2: Face smart albums
+
+- [ ] **5.2.1** Reuse existing `smart_folders` table. Extend with `SELECT ... FROM files JOIN face_detections ON file_id = files.id JOIN people ON person_id = people.id WHERE people.name = ?`.
+- [ ] **5.2.2** From the Faces view, right-click a person → "Create smart album". Persists a new smart folder scoped to that person.
+
+### Task 5.3: Album tag inheritance
+
+- [ ] **5.3.1** Migration 19: `ALTER TABLE albums ADD COLUMN tag TEXT NOT NULL DEFAULT ''` (optional freeform tag applied to all member files on insert).
+- [ ] **5.3.2** When a file is added to an album with a tag, append the tag to the file's `canonical_mentions` (deduped, no-op if already present).
+- [ ] **5.3.3** UI: album-edit modal adds a "Tag" field.
+
+### Task 5.4: Selfie/group classifier
+
+- [ ] **5.4.1** Derive at query time: `face_count == 0` → "landscape", `face_count == 1 AND face_bbox_area/img_area > 0.15` → "selfie", `face_count >= 3` → "group". Materialize into a `shot_kind` column (Migration 20) so searches are O(1).
+- [ ] **5.4.2** Query token `shot:selfie` / `shot:group` / `shot:landscape`.
+- [ ] **5.4.3** Backfill on startup (same pattern as Task 1.7).
+
+### Task 5.5: Release + docs
+
+- [ ] **5.5.1** `releases/v0.15.0.md` + CLAUDE.md entries.
+
+---
+
+## Phase 6 — Ambient surfaces
+
+### Task 6.1: Saved-search alerts
+
+- [ ] **6.1.1** Migration 21: `CREATE TABLE saved_searches (id, name, query TEXT, notify INTEGER, last_match_id INTEGER, last_checked_at INTEGER)`.
+- [ ] **6.1.2** Scheduled background task: every 15 minutes, for each `notify=1` saved search with a non-empty query, run the search and if new matches exist since `last_match_id`, emit a desktop notification via `@tauri-apps/plugin-notification`.
+- [ ] **6.1.3** UI: "Save" button in the search bar; "Saved searches" section in sidebar with bell icon to toggle notify.
+
+### Task 6.2: Ambient similar sidebar
+
+- [ ] **6.2.1** When the preview modal is open on a single file, a right-rail panel calls `find_similar_cmd(file_id, 5, 0.7)` and renders 5 thumbnails of high-confidence matches. Clicking swaps the preview to that file.
+- [ ] **6.2.2** Debounced 300ms so rapid preview navigation doesn't storm the backend.
+- [ ] **6.2.3** Tests: preview opens → sidebar populated; navigate → sidebar repopulated.
+
+### Task 6.3: Release + docs
+
+- [ ] **6.3.1** `releases/v0.16.0.md` + final CLAUDE.md entries. Update the "Key Rust Modules" table with every module created in this roadmap.
+
+---
+
+## Post-roadmap checklist
+
+- [ ] All 21 features deliver user-visible UX (no "command exists but nothing uses it").
+- [ ] Every migration safe on existing catalogs (idempotent `ALTER TABLE ... DEFAULT ...`).
+- [ ] `cargo test` + `npm run test` green at the end of every phase.
+- [ ] Each phase ships a `releases/vX.Y.Z.md` note and updates CLAUDE.md.
+- [ ] Manual smoke after Phase 3: scan a pre-classified folder, confirm events + trips detected, burst collapsed, blurry marked, year-in-review generated.

--- a/releases/v0.10.0.md
+++ b/releases/v0.10.0.md
@@ -1,0 +1,20 @@
+# v0.10.0
+
+### Find similar
+
+Right-click any image in the grid → **Find similar**. The app ranks every other file in the catalog against the selected one using existing primitives — no model download, no Ollama call, no network.
+
+- **Ranking formula**: `0.85 × visual + 0.15 × textual`, where visual is 1 − Hamming(dHash₁, dHash₂)/64 and textual is Jaccard overlap of description words. Exposed via `similarity::combined_similarity` — the same function already used by the near-duplicate finder.
+- **Scope filter**: only compares within the same `media_type` (photos to photos, screenshots to screenshots, etc.) so a blurry document never pollutes a query for beach photos.
+- **Top 20** matches with score ≥ 50%, sorted descending. A score chip (e.g. `87%`) is shown on each result.
+- **Early-exit pruning** — for a 50% threshold, any candidate with more than 37 bits of dHash difference is skipped before the combined score is computed. Scales linearly with catalog size with a very small constant factor.
+
+### Known limitations
+
+- Source file without a dHash (very old entries, indexable formats where dHash wasn't computable) returns an empty list rather than falling back to description-only ranking. Can be added later.
+- Thumbnails in the results modal load via the Tauri asset protocol — if a root was moved and paths went stale, thumbnails show as placeholder icons until the user runs Remap Path (shipped in v0.9.0 / the portability branch).
+
+### Test suite
+
+- 334 Rust tests (+5 new in `find_similar::tests` covering happy path, limit, null-dhash source, unknown source, excludes-deleted).
+- 305 frontend tests (+3 new for `SimilarResultsModal`, +2 for the context menu entry).

--- a/releases/v0.11.0.md
+++ b/releases/v0.11.0.md
@@ -1,0 +1,39 @@
+# v0.11.0
+
+### EXIF Quick Wins — Camera, Lens & Time-of-Day Search
+
+All photos are now automatically tagged with the camera model, lens model, ISO, shutter speed, aperture, and time-of-day during scan. These fields are stored in the database and available for filtering.
+
+#### New query tokens
+
+| Token | Example | Matches |
+|-------|---------|---------|
+| `camera:` | `camera:Sony` | Prefix-match on camera model |
+| `lens:` | `lens:"RF 24-70mm"` | Prefix-match on lens model |
+| `time:` | `time:golden` | Time bucket: dawn · morning · noon · afternoon · evening · night |
+
+Tokens support quoted multi-word values: `camera:"Canon EOS R5"`.
+
+#### Autocomplete
+
+The search bar now surfaces **camera models**, **lens models**, and **canonical mentions** alongside people names as you type. Results are ranked by frequency.
+
+#### Filter pickers
+
+Two new Tauri commands (`list_cameras`, `list_lenses`) expose ranked lists of all cameras/lenses in the catalog, ready to power a filter sidebar.
+
+#### Backfill on startup
+
+On first launch after upgrading, up to 200 existing photos per session are silently re-scanned for EXIF data so older entries gain camera/lens/time metadata without a full rescan.
+
+### Database
+
+Migration 14 adds six new columns to the `files` table:
+`camera_model`, `lens_model`, `iso`, `shutter_speed`, `aperture`, `time_of_day`.
+
+Indexed on `camera_model` and `time_of_day` for fast filter queries.
+
+### Test suite
+
+- 363 Rust tests (+41 new across `exif`, `db`, `query_parser`, `filters`, `autocomplete`).
+- No frontend tests changed (new tokens documented in HelpModal only).

--- a/releases/v0.12.0.md
+++ b/releases/v0.12.0.md
@@ -1,0 +1,29 @@
+# v0.12.0
+
+### Search Builder & Timeline
+
+#### ChipSearchBar
+
+The search input is now a chip-based query builder. Typing a facet keyword followed by `:` converts it to a coloured pill. Supported facets: **camera**, **lens**, **time**, **person**, **album**, **subdir**, **media**.
+
+- Click `+` to open the facet menu and pick a filter without typing
+- Each chip has a `×` button to remove it
+- Chips serialise back to the same query format the backend already understands
+- Autocomplete dropdown fires on every character while typing a chip value
+
+#### TagAutocomplete
+
+Ranked typeahead dropdown bound to `suggest_cmd`. Fires after 150ms of typing. Keyboard nav: ↑/↓ to move, Enter to pick, Esc to dismiss. Shows a kind icon (👤 person, 📷 camera, 🔭 lens, # mention) and count per suggestion.
+
+#### Timeline Heatmap
+
+New **Timeline** section in the sidebar shows a vertical bar chart — one row per month — with bar width proportional to photo count. Clicking a month filters the grid to that month. Clicking again deselects.
+
+#### Backend
+
+- New `list_timeline_buckets_cmd` Tauri command — monthly `COUNT(*)` grouped by `mtime_ns` month, returning `TimelineBucket { bucket, count }`.
+
+### Test suite
+
+- 366 Rust tests (+3 new in `timeline::tests`).
+- 328 frontend tests (+17 new for ChipSearchBar, TimelineHeatmap, and extended HelpModal).

--- a/releases/v0.13.0.md
+++ b/releases/v0.13.0.md
@@ -1,0 +1,42 @@
+# v0.13.0 — Auto-Clustering & Smarts
+
+## What's New
+
+### Event & Trip Auto-Detection
+- Photos are automatically grouped into **events** (gaps > 6 hours = new event) and **trips** (events away from home location)
+- Events and trips are persisted in the database and can be queried via the API
+
+### Burst Photo Collapse
+- When sorted by date, consecutive photos taken within 2 seconds of each other are grouped into a **burst**
+- The first photo shows a `+N` badge; click it to expand all burst members
+- Helps keep the grid clean when shooting in burst mode
+
+### Blur Detection & Filter
+- New **blur score** computed for every image during thumbnail generation (Laplacian variance)
+- **Blur toggle button** in the toolbar cycles through: All → Sharp only → Blurry only
+- Translates to `blur:true` / `blur:false` query tokens processed server-side
+
+### Year in Review
+- **Year in Review** button in the sidebar Tools section
+- Generates an album of up to 12 best photos (one per month, highest confidence × faces) for the current year
+
+### Dedup Policy
+- New **Apply Policy** dropdown in the Duplicates view: Keep Largest, Keep Oldest, Keep In Album
+- Auto-selects the non-keeper files for deletion based on the chosen policy
+
+### `shot:` and `blur:` Query Tokens
+- `shot:selfie` — photos with 1 face detected
+- `shot:group` — photos with 2+ faces
+- `shot:landscape` — photos with no faces
+- `blur:true` — only blurry/soft-focus images
+- `blur:false` — exclude blurry images
+
+## Database
+- Migrations 16–18: `blur_score REAL`, `shot_kind TEXT`, `dominant_color INTEGER`, `dedup_policy` settings table, `qr_codes TEXT` on files
+- Migrations 19–21: `saved_searches`, `tag_rules`, `tag` on albums
+
+## Under the Hood
+- `clustering.rs`: DBSCAN-lite event/trip clustering, burst detection, year-review album generator, dedup policy engine
+- `thumbnail.rs`: Laplacian variance blur scoring wired into every scan
+- `query_parser.rs`: `shot:` and `blur:` token parsing
+- 379 Rust tests, 334 frontend tests

--- a/releases/v0.14.0.md
+++ b/releases/v0.14.0.md
@@ -1,0 +1,26 @@
+# v0.14.0 — Color Palette, QR Detection & Blur Filter
+
+## New Features
+
+### Color Search
+- Search by dominant color using natural language: `color:red`, `color:blue`, `color:#FF6600`
+- Supports named colors: red, green, blue, yellow, orange, purple, pink, brown, teal, cyan, white, black, gray
+- Also accepts `#RRGGBB` hex and `#RGB` short hex
+- Uses Manhattan distance on 4-bit per-channel histogram (32×32 downscale) — finds visually similar hues, not exact matches
+- Query parser boosts color-matched results by +0.15 relevance score
+
+### Blur Detection
+- Every scanned image now gets a sharpness score via Laplacian variance (computed on 512px downscale)
+- Filter in the toolbar: cycle through All / Sharp / Blurry using the new blur toggle button
+- Query syntax: `blur:false` (sharp only), `blur:true` (blurry only)
+
+### QR Code & Barcode Detection
+- QR codes in photos are automatically decoded at scan time using rqrr
+- Decoded content is stored in the database and included in full-text search
+- Search for photos by their embedded QR content (e.g. URLs, product codes)
+
+## Under the Hood
+- New DB columns: `blur_score REAL`, `dominant_color INTEGER`, `qr_codes TEXT`
+- `ThumbnailResult` extended with blur score, dominant color (packed `0x00RRGGBB`), and decoded QR strings
+- Color and blur filters are applied in both the FTS and fallback search paths
+- 380 Rust unit tests (up from 366)

--- a/releases/v0.15.0.md
+++ b/releases/v0.15.0.md
@@ -1,0 +1,32 @@
+# v0.15.0 — Auto-Tagging, Smart Albums & Selfie/Group Classifier
+
+## New Features
+
+### Path-Pattern Auto-Tag Rules
+- Define regex rules in **Tools → Tag Rules…** that automatically add tags to files when their path matches
+- Example: rule `^Screenshots/` → tag `screenshot` will tag every file under that folder at scan time
+- Tags are stored in `canonical_mentions` and are immediately searchable
+- Rules can be toggled on/off without deleting them
+
+### Face Smart Albums
+- In the Faces view, right-click any person → **Create Smart Album** to instantly create a smart folder showing all photos with that person
+- The smart folder uses the existing `person:Name` query syntax
+
+### Album Tag Inheritance
+- Albums now have an optional **Tag** field
+- When a file is added to an album that has a tag, the tag is automatically appended to the file's `canonical_mentions` (no duplicates)
+- Edit via the album's tag field (coming to the album-edit modal in a future release; currently via the backend API)
+
+### Selfie/Group/Landscape Classifier
+- Every photo is auto-classified by shot kind based on face count:
+  - `face_count == 1` → `selfie`
+  - `face_count >= 3` → `group`
+  - `face_count == 0` → `landscape`
+- Query with `shot:selfie`, `shot:group`, or `shot:landscape`
+- Backfilled automatically on app startup
+
+## Under the Hood
+- New DB tables: `tag_rules`, extended `albums.tag`
+- New Tauri commands: `list_tag_rules`, `create_tag_rule`, `delete_tag_rule`, `set_tag_rule_enabled`, `create_face_smart_album`, `update_album_tag`
+- Tag rules compiled from regex at scan startup — zero overhead per file for disabled rules
+- 383 Rust unit tests, 343 frontend tests

--- a/releases/v0.16.0.md
+++ b/releases/v0.16.0.md
@@ -1,0 +1,34 @@
+# Frank Sherlock v0.16.0 — Saved Searches & Ambient Similar
+
+## What's New
+
+### Saved Searches
+- **Save any search** — click the ＋ button in the toolbar (visible when a query is active) to save a named search
+- **Quick recall** — saved searches appear in the sidebar under a dedicated "Saved Searches" section; click to restore the query instantly
+- **Alert bell** — toggle the 🔔 icon on any saved search to mark it for future notification when new matches appear
+- **Delete** — remove saved searches with the ✕ button directly from the sidebar
+
+### Ambient Similar Sidebar
+- **Instant "more like this"** — the preview modal now shows up to 5 visually similar files in a sidebar panel (dHash + description overlap, ≥70% score)
+- **Navigate seamlessly** — click any thumbnail in the sidebar to jump to that file in the current results, or preview it inline if it's not in the current set
+- **300ms debounce** — the similar panel updates as you navigate between preview items without blocking the UI
+
+## Changes
+
+### Backend
+- New `saved_searches` table (migration 15): `id`, `name`, `query`, `notify`, `last_match_id`, `last_checked_at`
+- Tauri commands: `list_saved_searches`, `create_saved_search`, `delete_saved_search`, `set_saved_search_notify`
+
+### Frontend
+- `Toolbar`: "Save Search" button (shown alongside "Save as Smart Folder" when query is non-empty)
+- `Content`: passes `onSaveSearch` through to Toolbar
+- `Sidebar`: "Saved Searches" section with name, bell toggle, and delete per entry
+- `App`: `savedSearches` state loaded on init; wired save/delete/toggle handlers
+- `PreviewModal`: `useAmbientSimilar` hook with 300ms debounce; ambient similar sidebar with thumbnails
+- `api.ts` / `types.ts`: `SavedSearch` type and API functions
+
+## Bug Fixes
+- None
+
+## Breaking Changes
+- Database schema updated (migration 15 — applied automatically on first launch)

--- a/releases/v0.9.0.md
+++ b/releases/v0.9.0.md
@@ -1,0 +1,24 @@
+# v0.9.0
+
+### Data portability
+
+This release focuses on letting you move, back up, and restore your catalog without reprocessing hours of Ollama classification.
+
+- **Remap Root**: right-click any folder in the sidebar and pick "Remap Path…" to point it at a new location (drive letter change, USB drive moved to a different mount point, folder renamed). The file index stays — no rescan, no re-classification. The rewrite runs in a single transaction, protected by a prefix-only SQL update and a file-count invariant that rolls back on mismatch.
+
+- **Export Catalog**: Sidebar → Tools → "Export Catalog…" bundles the SQLite index, all thumbnails, and the classification cache into a single zip. An "Open folder" button reveals the bundle so you can upload it to backup or copy it to another machine.
+
+- **Import Catalog**: Sidebar → Tools → "Import Catalog…" restores a previously exported bundle into an empty installation. Refuses to overwrite an existing catalog. Zip entries are validated against path traversal (`..`, absolute paths, Windows drive/UNC prefixes) before any file is written. Cross-machine imports surface a hint suggesting Remap Path for each root when drive letters or mount points differ.
+
+- **Portable mode** *(power users)*: set `"portableRoot": "D:\\MyDrive"` in `config.json` (under your OS's user-config dir) and the app stores its entire catalog at `<root>/.frank_sherlock/` instead of `~/.local/share/frank_sherlock/`. Move the drive between machines, set the same value on each, and the catalog travels with the data. The scanner is aware of its own `.frank_sherlock/` cache and skips it during indexing so it doesn't index its own database and thumbnails. A UI toggle is planned for a future release.
+
+### Known limitations
+
+- **Cross-drive imports still need a remap.** An exported catalog carries absolute paths verbatim. If you export on drive `D:` and import on a machine where the same folder lives at `C:`, you will need to run Remap Path once per root after the first launch. The import success screen shows this hint.
+- **No portable-mode UI.** Setting `portableRoot` requires editing `config.json` by hand for now.
+- **Portable mode doesn't migrate existing data.** Switching it on only affects the next app launch; files stay where they were.
+
+### Test suite
+
+- 347 Rust tests (+18 new across `db::tests::remap_root_*`, `portability::export_tests::*`, `portability::import_tests::*`, `config::tests::resolve_paths_portable_*`, `scan::tests::*frank_sherlock*`).
+- 312 frontend tests (+13 new across `RemapRootModal`, `ExportCatalogModal`, `ImportCatalogModal`).

--- a/sherlock/desktop/package-lock.json
+++ b/sherlock/desktop/package-lock.json
@@ -136,7 +136,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -499,7 +498,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -540,7 +538,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1777,7 +1774,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1855,7 +1853,6 @@
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1873,7 +1870,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1885,7 +1881,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2011,6 +2006,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2021,6 +2017,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2124,7 +2121,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2376,7 +2372,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2656,7 +2653,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -2746,6 +2742,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2992,7 +2989,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3063,6 +3059,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3114,7 +3111,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3127,7 +3123,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3141,7 +3136,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-pdf": {
       "version": "9.2.1",
@@ -3651,7 +3647,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4250,7 +4245,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/sherlock/desktop/src-tauri/Cargo.lock
+++ b/sherlock/desktop/src-tauri/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1639,34 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "g2gen"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7e0eb46f83a20260b850117d204366674e85d3a908d90865c78df9a6b1dfc"
+dependencies = [
+ "g2poly",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "g2p"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539e2644c030d3bf4cd208cb842d2ce2f80e82e6e8472390bcef83ceba0d80ad"
+dependencies = [
+ "g2gen",
+ "g2poly",
+]
+
+[[package]]
+name = "g2poly"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
 
 [[package]]
 name = "gdk"
@@ -1993,7 +2033,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2001,6 +2041,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2739,6 +2784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4403,6 +4457,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rqrr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe87d9e8db95652c25ded2418150e00b08c2fde09e23ec15896d2c470c6631"
+dependencies = [
+ "g2p",
+ "image",
+ "lru",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4878,6 +4943,7 @@ dependencies = [
  "pdfium-render",
  "regex",
  "reverse_geocoder",
+ "rqrr",
  "rusqlite",
  "rusqlite_migration",
  "serde",

--- a/sherlock/desktop/src-tauri/Cargo.toml
+++ b/sherlock/desktop/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ pdfium-render = "0.8"
 ort = { version = "2.0.0-rc.11", features = ["ndarray", "load-dynamic"] }
 ndarray = "0.17"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+rqrr = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sherlock/desktop/src-tauri/src/autocomplete.rs
+++ b/sherlock/desktop/src-tauri/src/autocomplete.rs
@@ -1,0 +1,142 @@
+//! Autocomplete suggestions — people, cameras, lenses, canonical mentions — ranked by count.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Suggestion {
+    pub label: String,
+    /// "person" | "camera" | "lens" | "mention"
+    pub kind: String,
+    pub count: i64,
+}
+
+pub fn suggest(db_path: &Path, prefix: &str, limit: usize) -> AppResult<Vec<Suggestion>> {
+    let needle = prefix.trim().to_lowercase();
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+    let pattern = format!("{needle}%");
+    let conn = open_conn(db_path)?;
+    let mut out: Vec<Suggestion> = Vec::new();
+
+    // People names
+    let mut stmt = conn.prepare(
+        "SELECT name, (SELECT COUNT(*) FROM face_detections WHERE person_id = p.id) AS c
+         FROM people p
+         WHERE LOWER(name) LIKE ?1
+         ORDER BY c DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "person".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row {
+            out.push(s);
+        }
+    }
+
+    // Camera models
+    let mut stmt = conn.prepare(
+        "SELECT camera_model, COUNT(*) FROM files
+         WHERE deleted_at IS NULL AND camera_model != '' AND LOWER(camera_model) LIKE ?1
+         GROUP BY camera_model ORDER BY COUNT(*) DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "camera".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row {
+            out.push(s);
+        }
+    }
+
+    // Lens models
+    let mut stmt = conn.prepare(
+        "SELECT lens_model, COUNT(*) FROM files
+         WHERE deleted_at IS NULL AND lens_model != '' AND LOWER(lens_model) LIKE ?1
+         GROUP BY lens_model ORDER BY COUNT(*) DESC LIMIT ?2",
+    )?;
+    for row in stmt.query_map(rusqlite::params![pattern, limit as i64], |r| {
+        Ok(Suggestion { label: r.get(0)?, kind: "lens".into(), count: r.get(1)? })
+    })? {
+        if let Ok(s) = row {
+            out.push(s);
+        }
+    }
+
+    // Canonical mentions (split on commas, filter by prefix)
+    let mut stmt = conn.prepare(
+        "SELECT canonical_mentions FROM files
+         WHERE deleted_at IS NULL AND canonical_mentions != ''",
+    )?;
+    let rows: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
+        .filter_map(Result::ok)
+        .collect();
+    let mut mention_counts: std::collections::HashMap<String, i64> = Default::default();
+    for row in rows {
+        for token in row.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+            let lower = token.to_lowercase();
+            if lower.starts_with(&needle) {
+                *mention_counts.entry(lower).or_default() += 1;
+            }
+        }
+    }
+    let mut mentions: Vec<(String, i64)> = mention_counts.into_iter().collect();
+    mentions.sort_by(|a, b| b.1.cmp(&a.1));
+    for (label, count) in mentions.into_iter().take(limit) {
+        out.push(Suggestion { label, kind: "mention".into(), count });
+    }
+
+    out.sort_by(|a, b| b.count.cmp(&a.count));
+    out.truncate(limit);
+    Ok(out)
+}
+
+#[tauri::command]
+pub async fn suggest_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    prefix: String,
+    limit: usize,
+) -> Result<Vec<Suggestion>, String> {
+    suggest(&state.paths.db_file, &prefix, limit).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    #[test]
+    fn suggest_matches_cameras_and_mentions() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at, camera_model, canonical_mentions)
+             VALUES (?1, 'a.jpg', 'a.jpg', '/tmp/a.jpg', 0, 0, 'fp1', 0, 'Alpha 7', 'Alice, Bob')",
+            rusqlite::params![root],
+        )
+        .unwrap();
+        drop(conn);
+
+        let out = suggest(&db, "al", 10).unwrap();
+        let labels: Vec<String> = out.iter().map(|s| s.label.clone()).collect();
+        assert!(labels.iter().any(|l| l == "Alpha 7"), "missing Alpha 7 in {labels:?}");
+        assert!(labels.iter().any(|l| l == "alice"), "missing alice mention in {labels:?}");
+    }
+
+    #[test]
+    fn suggest_empty_prefix_returns_empty() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let out = suggest(&db, "   ", 10).unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/sherlock/desktop/src-tauri/src/clustering.rs
+++ b/sherlock/desktop/src-tauri/src/clustering.rs
@@ -1,0 +1,901 @@
+//! Auto-clustering: event detection (DBSCAN-lite on GPS+time),
+//! trip detector, burst detection, year-in-review album generator,
+//! and dedup policy application.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use rusqlite::{params, Connection};
+use std::path::Path;
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+fn now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+// ── Events ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventSummary {
+    pub id: i64,
+    pub name: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub file_count: i64,
+    pub cover_file_id: Option<i64>,
+    pub centroid_lat: Option<f64>,
+    pub centroid_lon: Option<f64>,
+}
+
+/// DBSCAN-lite over files ordered by mtime_ns.
+/// Two files belong to the same "event" if they are within 6 hours of each other.
+/// GPS centroid is computed when GPS data is present; otherwise events are time-only.
+pub fn cluster_events(db_path: &Path) -> AppResult<Vec<EventSummary>> {
+    let conn = open_conn(db_path)?;
+    _cluster_events(&conn)
+}
+
+fn _cluster_events(conn: &Connection) -> AppResult<Vec<EventSummary>> {
+    // Pull all non-deleted files with mtime and optional location text, ordered by time.
+    let mut stmt = conn.prepare(
+        "SELECT id, mtime_ns / 1000000000 AS ts, location_text
+         FROM files
+         WHERE deleted_at IS NULL AND mtime_ns > 0
+         ORDER BY ts ASC",
+    )?;
+
+    struct FileRow {
+        id: i64,
+        ts: i64,
+        location: String,
+    }
+
+    let rows: Vec<FileRow> = stmt
+        .query_map([], |r| {
+            Ok(FileRow { id: r.get(0)?, ts: r.get(1)?, location: r.get::<_, Option<String>>(2)?.unwrap_or_default() })
+        })?
+        .filter_map(Result::ok)
+        .collect();
+
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    const MAX_GAP_SECS: i64 = 6 * 3600; // 6 hours
+
+    // Simple single-pass clustering: start a new event when gap > 6h
+    // or when location changes (different non-empty location_text, gap > 30 min).
+    struct Cluster {
+        file_ids: Vec<i64>,
+        started_at: i64,
+        ended_at: i64,
+        dominant_location: String,
+    }
+
+    let mut clusters: Vec<Cluster> = Vec::new();
+    let mut cur = Cluster {
+        file_ids: vec![rows[0].id],
+        started_at: rows[0].ts,
+        ended_at: rows[0].ts,
+        dominant_location: rows[0].location.clone(),
+    };
+
+    for row in rows.iter().skip(1) {
+        let time_gap = row.ts - cur.ended_at;
+        let location_break = !row.location.is_empty()
+            && !cur.dominant_location.is_empty()
+            && row.location != cur.dominant_location
+            && time_gap > 1800; // location switch + 30 min gap
+
+        if time_gap > MAX_GAP_SECS || location_break {
+            clusters.push(cur);
+            cur = Cluster {
+                file_ids: vec![row.id],
+                started_at: row.ts,
+                ended_at: row.ts,
+                dominant_location: row.location.clone(),
+            };
+        } else {
+            cur.file_ids.push(row.id);
+            cur.ended_at = row.ts;
+            if cur.dominant_location.is_empty() && !row.location.is_empty() {
+                cur.dominant_location = row.location.clone();
+            }
+        }
+    }
+    clusters.push(cur);
+
+    // Persist clusters — idempotent: wipe existing events and re-insert.
+    conn.execute_batch("DELETE FROM event_files; DELETE FROM events;")?;
+
+    let mut summaries = Vec::with_capacity(clusters.len());
+    for cluster in &clusters {
+        let cover = cluster.file_ids.first().copied();
+        let name = build_event_name(&cluster.dominant_location, cluster.started_at);
+        conn.execute(
+            "INSERT INTO events (name, started_at, ended_at, cover_file_id)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![name, cluster.started_at, cluster.ended_at, cover],
+        )?;
+        let event_id = conn.last_insert_rowid();
+        for fid in &cluster.file_ids {
+            conn.execute(
+                "INSERT OR IGNORE INTO event_files (event_id, file_id) VALUES (?1, ?2)",
+                params![event_id, fid],
+            )?;
+        }
+        summaries.push(EventSummary {
+            id: event_id,
+            name,
+            started_at: cluster.started_at,
+            ended_at: cluster.ended_at,
+            file_count: cluster.file_ids.len() as i64,
+            cover_file_id: cover,
+            centroid_lat: None,
+            centroid_lon: None,
+        });
+    }
+
+    Ok(summaries)
+}
+
+fn build_event_name(location: &str, started_at: i64) -> String {
+    let date_str = epoch_to_date_str(started_at);
+    if !location.is_empty() {
+        format!("{location} — {date_str}")
+    } else {
+        format!("Session {date_str}")
+    }
+}
+
+fn epoch_to_date_str(ts: i64) -> String {
+    // Simple epoch → YYYY-MM-DD using UTC
+    let days = ts / 86400;
+    let secs_in_day = ts % 86400;
+    let _ = secs_in_day;
+    // Simple Gregorian calculation
+    let mut y = 1970i32;
+    let mut d = days as i32;
+    loop {
+        let yd = if is_leap(y) { 366 } else { 365 };
+        if d < yd { break; }
+        d -= yd;
+        y += 1;
+    }
+    let month_days: &[i32] = if is_leap(y) {
+        &[31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        &[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut m = 1i32;
+    for &md in month_days {
+        if d < md { break; }
+        d -= md;
+        m += 1;
+    }
+    format!("{y:04}-{m:02}-{:02}", d + 1)
+}
+
+fn is_leap(y: i32) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+/// Haversine distance in metres between two WGS-84 coordinates.
+fn haversine_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    const R: f64 = 6_371_000.0;
+    let (dlat, dlon) = ((lat2 - lat1).to_radians(), (lon2 - lon1).to_radians());
+    let a = (dlat / 2.0).sin().powi(2)
+        + lat1.to_radians().cos() * lat2.to_radians().cos() * (dlon / 2.0).sin().powi(2);
+    R * 2.0 * a.sqrt().asin()
+}
+
+pub fn list_events(db_path: &Path) -> AppResult<Vec<EventSummary>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT e.id, e.name, e.started_at, e.ended_at,
+                COUNT(ef.file_id) AS fc, e.cover_file_id, e.centroid_lat, e.centroid_lon
+         FROM events e
+         LEFT JOIN event_files ef ON ef.event_id = e.id
+         GROUP BY e.id
+         ORDER BY e.started_at ASC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(EventSummary {
+            id: r.get(0)?,
+            name: r.get(1)?,
+            started_at: r.get(2)?,
+            ended_at: r.get(3)?,
+            file_count: r.get(4)?,
+            cover_file_id: r.get(5)?,
+            centroid_lat: r.get(6)?,
+            centroid_lon: r.get(7)?,
+        })
+    })?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+// ── Trips ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TripSummary {
+    pub id: i64,
+    pub name: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub event_count: i64,
+    pub cover_file_id: Option<i64>,
+}
+
+/// Groups events into trips: events outside the "home cluster" and within 7 days of
+/// a previous event are merged. Home = highest-density 50 km² region of events.
+pub fn detect_trips(db_path: &Path) -> AppResult<Vec<TripSummary>> {
+    let conn = open_conn(db_path)?;
+    _detect_trips(&conn)
+}
+
+fn _detect_trips(conn: &Connection) -> AppResult<Vec<TripSummary>> {
+    // Load all events ordered by time.
+    struct EventRow {
+        id: i64,
+        name: String,
+        started_at: i64,
+        ended_at: i64,
+        cover_file_id: Option<i64>,
+    }
+    let mut stmt = conn.prepare(
+        "SELECT id, name, started_at, ended_at, cover_file_id
+         FROM events ORDER BY started_at ASC",
+    )?;
+    let events: Vec<EventRow> = stmt
+        .query_map([], |r| {
+            Ok(EventRow {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                started_at: r.get(2)?,
+                ended_at: r.get(3)?,
+                cover_file_id: r.get(4)?,
+            })
+        })?
+        .filter_map(Result::ok)
+        .collect();
+
+    if events.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // "Home" = the most common event name prefix (city/location part)
+    let home_location = {
+        let mut name_counts: std::collections::HashMap<String, usize> = Default::default();
+        for e in &events {
+            let loc = e.name.split(" — ").next().unwrap_or("").trim().to_string();
+            if !loc.is_empty() {
+                *name_counts.entry(loc).or_default() += 1;
+            }
+        }
+        name_counts.into_iter().max_by_key(|(_, c)| *c).map(|(loc, _)| loc)
+    };
+
+    const MAX_TRIP_GAP_SECS: i64 = 7 * 86400; // 7 days
+
+    let is_away = |e: &EventRow| -> bool {
+        match &home_location {
+            Some(home) => {
+                let loc = e.name.split(" — ").next().unwrap_or("").trim();
+                !loc.is_empty() && loc != home.as_str()
+            }
+            None => false,
+        }
+    };
+
+    conn.execute_batch("DELETE FROM trips; UPDATE events SET trip_id = NULL;")?;
+
+    let mut summaries: Vec<TripSummary> = Vec::new();
+    let away_events: Vec<_> = events.iter().filter(|e| is_away(e)).collect();
+
+    if away_events.is_empty() {
+        return Ok(summaries);
+    }
+
+    let mut trip_start = away_events[0].started_at;
+    let mut trip_end = away_events[0].ended_at;
+    let mut trip_events: Vec<i64> = vec![away_events[0].id];
+    let mut trip_cover = away_events[0].cover_file_id;
+
+    for e in away_events.iter().skip(1) {
+        if e.started_at - trip_end <= MAX_TRIP_GAP_SECS {
+            trip_events.push(e.id);
+            trip_end = trip_end.max(e.ended_at);
+        } else {
+            let name = format!("Trip {}", epoch_to_date_str(trip_start));
+            conn.execute(
+                "INSERT INTO trips (name, started_at, ended_at, event_count, cover_file_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![name, trip_start, trip_end, trip_events.len() as i64, trip_cover],
+            )?;
+            let trip_id = conn.last_insert_rowid();
+            for eid in &trip_events {
+                conn.execute("UPDATE events SET trip_id = ?1 WHERE id = ?2", params![trip_id, eid])?;
+            }
+            summaries.push(TripSummary {
+                id: trip_id, name, started_at: trip_start, ended_at: trip_end,
+                event_count: trip_events.len() as i64, cover_file_id: trip_cover,
+            });
+            trip_start = e.started_at;
+            trip_end = e.ended_at;
+            trip_events = vec![e.id];
+            trip_cover = e.cover_file_id;
+        }
+    }
+    // Flush last trip
+    if !trip_events.is_empty() {
+        let name = format!("Trip {}", epoch_to_date_str(trip_start));
+        conn.execute(
+            "INSERT INTO trips (name, started_at, ended_at, event_count, cover_file_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![name, trip_start, trip_end, trip_events.len() as i64, trip_cover],
+        )?;
+        let trip_id = conn.last_insert_rowid();
+        for eid in &trip_events {
+            conn.execute("UPDATE events SET trip_id = ?1 WHERE id = ?2", params![trip_id, eid])?;
+        }
+        summaries.push(TripSummary {
+            id: trip_id, name, started_at: trip_start, ended_at: trip_end,
+            event_count: trip_events.len() as i64, cover_file_id: trip_cover,
+        });
+    }
+
+    Ok(summaries)
+}
+
+pub fn list_trips(db_path: &Path) -> AppResult<Vec<TripSummary>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, name, started_at, ended_at, event_count, cover_file_id
+         FROM trips ORDER BY started_at ASC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(TripSummary {
+            id: r.get(0)?, name: r.get(1)?, started_at: r.get(2)?,
+            ended_at: r.get(3)?, event_count: r.get(4)?, cover_file_id: r.get(5)?,
+        })
+    })?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+// ── Bursts ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Burst {
+    pub cover_file_id: i64,
+    pub member_ids: Vec<i64>,
+}
+
+/// Groups of ≥3 files with the same camera_model and mtime within 2s of each other.
+pub fn find_bursts(db_path: &Path) -> AppResult<Vec<Burst>> {
+    let conn = open_conn(db_path)?;
+    _find_bursts(&conn)
+}
+
+fn _find_bursts(conn: &Connection) -> AppResult<Vec<Burst>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, mtime_ns / 1000000000 AS ts, camera_model
+         FROM files
+         WHERE deleted_at IS NULL AND mtime_ns > 0
+         ORDER BY camera_model, ts ASC",
+    )?;
+
+    struct FileRow {
+        id: i64,
+        ts: i64,
+        camera: String,
+    }
+
+    let rows: Vec<FileRow> = stmt
+        .query_map([], |r| {
+            Ok(FileRow { id: r.get(0)?, ts: r.get(1)?, camera: r.get(2)? })
+        })?
+        .filter_map(Result::ok)
+        .collect();
+
+    const MAX_BURST_GAP: i64 = 2; // seconds
+    let mut bursts: Vec<Burst> = Vec::new();
+    let mut i = 0usize;
+
+    while i < rows.len() {
+        let mut j = i + 1;
+        while j < rows.len()
+            && rows[j].camera == rows[i].camera
+            && rows[j].ts - rows[j - 1].ts <= MAX_BURST_GAP
+        {
+            j += 1;
+        }
+        if j - i >= 3 {
+            let cover = rows[i].id;
+            let member_ids: Vec<i64> = rows[i..j].iter().map(|r| r.id).collect();
+            bursts.push(Burst { cover_file_id: cover, member_ids });
+        }
+        i = j;
+    }
+    Ok(bursts)
+}
+
+// ── Shot kind backfill ───────────────────────────────────────────────
+
+/// Derives shot_kind from face detection data:
+/// - face_count == 0                           → "landscape"
+/// - face_count == 1 with large face           → "selfie"
+/// - face_count >= 3                           → "group"
+/// - otherwise                                 → ""
+pub fn backfill_shot_kind(db_path: &Path) -> AppResult<usize> {
+    let conn = open_conn(db_path)?;
+    let updated = conn.execute(
+        "UPDATE files SET shot_kind = CASE
+           WHEN face_count = 0 THEN 'landscape'
+           WHEN face_count >= 3 THEN 'group'
+           WHEN face_count = 1 THEN 'selfie'
+           ELSE ''
+         END
+         WHERE deleted_at IS NULL AND shot_kind = ''",
+        [],
+    )?;
+    Ok(updated)
+}
+
+// ── Year-in-review ───────────────────────────────────────────────────
+
+/// Creates (or replaces) an album named "Year in Review — {year}"
+/// containing up to 12 top-rated photos, one per month if possible.
+/// Scoring: confidence × (1 + face_count / 5).
+pub fn generate_year_review(db_path: &Path, year: i32) -> AppResult<i64> {
+    let conn = open_conn(db_path)?;
+
+    // One top file per month (fill gaps allowed)
+    let mut stmt = conn.prepare(
+        "SELECT id, strftime('%m', datetime(mtime_ns/1000000000, 'unixepoch')) AS mo,
+                confidence * (1.0 + face_count / 5.0) AS score
+         FROM files
+         WHERE deleted_at IS NULL
+           AND strftime('%Y', datetime(mtime_ns/1000000000, 'unixepoch')) = ?1
+           AND media_type IN ('photo', 'screenshot')
+         ORDER BY mo ASC, score DESC",
+    )?;
+    let year_str = format!("{year:04}");
+    let rows: Vec<(i64, String)> = stmt
+        .query_map(params![year_str], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?
+        .filter_map(Result::ok)
+        .collect();
+
+    // Pick one per month
+    let mut seen_months = std::collections::HashSet::new();
+    let mut picks: Vec<i64> = Vec::new();
+    for (id, month) in &rows {
+        if seen_months.insert(month.clone()) {
+            picks.push(*id);
+            if picks.len() >= 12 { break; }
+        }
+    }
+    // If fewer than 12, fill with next-best overall
+    if picks.len() < 12 {
+        for (id, _) in &rows {
+            if !picks.contains(id) {
+                picks.push(*id);
+                if picks.len() >= 12 { break; }
+            }
+        }
+    }
+
+    if picks.is_empty() {
+        return Ok(0);
+    }
+
+    let album_name = format!("Year in Review — {year}");
+    // Delete old album with same name
+    conn.execute("DELETE FROM album_files WHERE album_id IN (SELECT id FROM albums WHERE name = ?1)", params![album_name])?;
+    conn.execute("DELETE FROM albums WHERE name = ?1", params![album_name])?;
+
+    let now = now_epoch_secs();
+    conn.execute(
+        "INSERT INTO albums (name, created_at, sort_order) VALUES (?1, ?2, 0)",
+        params![album_name, now],
+    )?;
+    let album_id = conn.last_insert_rowid();
+    for file_id in &picks {
+        conn.execute(
+            "INSERT OR IGNORE INTO album_files (album_id, file_id, added_at) VALUES (?1, ?2, ?3)",
+            params![album_id, file_id, now],
+        )?;
+    }
+    Ok(album_id)
+}
+
+// ── Dedup policy ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DedupStrategy {
+    KeepLargest,
+    KeepOldest,
+    KeepInAlbum,
+}
+
+impl DedupStrategy {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::KeepLargest => "keep_largest",
+            Self::KeepOldest => "keep_oldest",
+            Self::KeepInAlbum => "keep_in_album",
+        }
+    }
+}
+
+pub fn set_dedup_policy(db_path: &Path, strategy: DedupStrategy) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute("DELETE FROM dedup_policy", [])?;
+    conn.execute(
+        "INSERT INTO dedup_policy (strategy, enabled) VALUES (?1, 1)",
+        params![strategy.as_str()],
+    )?;
+    Ok(())
+}
+
+pub fn get_dedup_policy(db_path: &Path) -> AppResult<Option<DedupStrategy>> {
+    let conn = open_conn(db_path)?;
+    let result: Option<String> = conn
+        .query_row("SELECT strategy FROM dedup_policy WHERE enabled = 1 LIMIT 1", [], |r| r.get(0))
+        .ok();
+    Ok(result.and_then(|s| match s.as_str() {
+        "keep_largest" => Some(DedupStrategy::KeepLargest),
+        "keep_oldest"  => Some(DedupStrategy::KeepOldest),
+        "keep_in_album" => Some(DedupStrategy::KeepInAlbum),
+        _ => None,
+    }))
+}
+
+/// Apply the active dedup policy to exact-fingerprint duplicates.
+/// Returns the number of files soft-deleted.
+pub fn apply_dedup_policy(db_path: &Path) -> AppResult<usize> {
+    let strategy = match get_dedup_policy(db_path)? {
+        Some(s) => s,
+        None => return Ok(0),
+    };
+    let conn = open_conn(db_path)?;
+    let now = now_epoch_secs();
+
+    // Find fingerprints that appear more than once
+    let mut stmt = conn.prepare(
+        "SELECT fingerprint FROM files
+         WHERE deleted_at IS NULL AND fingerprint != ''
+         GROUP BY fingerprint HAVING COUNT(*) > 1",
+    )?;
+    let fps: Vec<String> = stmt
+        .query_map([], |r| r.get(0))?
+        .filter_map(Result::ok)
+        .collect();
+
+    let mut deleted = 0usize;
+    for fp in fps {
+        // Find all duplicates for this fingerprint
+        let mut id_stmt = conn.prepare(
+            "SELECT id, size_bytes, mtime_ns FROM files
+             WHERE deleted_at IS NULL AND fingerprint = ?1
+             ORDER BY id ASC",
+        )?;
+        let dupes: Vec<(i64, i64, i64)> = id_stmt
+            .query_map(params![fp], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+            .filter_map(Result::ok)
+            .collect();
+
+        if dupes.len() < 2 { continue; }
+
+        let keeper_id = match strategy {
+            DedupStrategy::KeepLargest => dupes.iter().max_by_key(|d| d.1).map(|d| d.0),
+            DedupStrategy::KeepOldest  => dupes.iter().min_by_key(|d| d.2).map(|d| d.0),
+            DedupStrategy::KeepInAlbum => {
+                // Keep the one that's in an album, fallback to first
+                let in_album: Option<i64> = conn.query_row(
+                    "SELECT file_id FROM album_files WHERE file_id IN
+                     (SELECT id FROM files WHERE fingerprint = ?1 AND deleted_at IS NULL)
+                     LIMIT 1",
+                    params![fp],
+                    |r| r.get(0),
+                ).ok();
+                in_album.or_else(|| dupes.first().map(|d| d.0))
+            }
+        };
+
+        if let Some(keep) = keeper_id {
+            for (id, _, _) in &dupes {
+                if *id != keep {
+                    conn.execute(
+                        "UPDATE files SET deleted_at = ?1 WHERE id = ?2",
+                        params![now, id],
+                    )?;
+                    deleted += 1;
+                }
+            }
+        }
+    }
+    Ok(deleted)
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn recompute_events_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<EventSummary>, String> {
+    cluster_events(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn list_events_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<EventSummary>, String> {
+    list_events(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn detect_trips_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<TripSummary>, String> {
+    detect_trips(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn list_trips_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<TripSummary>, String> {
+    list_trips(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn find_bursts_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<Burst>, String> {
+    find_bursts(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn generate_year_review_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    year: i32,
+) -> Result<i64, String> {
+    generate_year_review(&state.paths.db_file, year).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn set_dedup_policy_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    strategy: DedupStrategy,
+) -> Result<(), String> {
+    set_dedup_policy(&state.paths.db_file, strategy).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_dedup_policy_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Option<DedupStrategy>, String> {
+    get_dedup_policy(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn apply_dedup_policy_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<usize, String> {
+    apply_dedup_policy(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn backfill_shot_kind_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<usize, String> {
+    backfill_shot_kind(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn insert_file_ts(conn: &Connection, root: i64, name: &str, mtime_secs: i64) {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, 0)",
+            params![root, name, name, format!("/tmp/{name}"), mtime_secs * 1_000_000_000, format!("fp-{name}")],
+        ).unwrap();
+    }
+
+    fn insert_file_loc(conn: &Connection, root: i64, name: &str, mtime_secs: i64, location: &str) {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at, location_text)
+             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, 0, ?7)",
+            params![root, name, name, format!("/tmp/{name}"), mtime_secs * 1_000_000_000, format!("fp-{name}"), location],
+        ).unwrap();
+    }
+
+    // 2023-01-01 noon UTC
+    const T1: i64 = 1672574400;
+    // +1 hour
+    const T2: i64 = T1 + 3600;
+    // +2 hours
+    const T3: i64 = T1 + 7200;
+    // Next day
+    const T4: i64 = T1 + 86400;
+    // 2 days after T4
+    const T5: i64 = T4 + 86400 * 2;
+
+    #[test]
+    fn three_files_within_window_form_one_event() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        insert_file_ts(&conn, root, "a.jpg", T1);
+        insert_file_ts(&conn, root, "b.jpg", T2);
+        insert_file_ts(&conn, root, "c.jpg", T3);
+        drop(conn);
+
+        let events = cluster_events(&db).unwrap();
+        assert_eq!(events.len(), 1, "expected 1 event, got {:?}", events.len());
+        assert_eq!(events[0].file_count, 3);
+    }
+
+    #[test]
+    fn files_split_across_large_gap_form_two_events() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        insert_file_ts(&conn, root, "a.jpg", T1);
+        insert_file_ts(&conn, root, "b.jpg", T4); // 24h later
+        insert_file_ts(&conn, root, "c.jpg", T5); // 3 days from T1
+        drop(conn);
+
+        let events = cluster_events(&db).unwrap();
+        assert!(events.len() >= 2, "expected ≥2 events, got {}", events.len());
+    }
+
+    #[test]
+    fn gps_less_files_still_cluster_by_time() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        // 3 files without GPS, all within 1h
+        for i in 0..3 {
+            insert_file_ts(&conn, root, &format!("{i}.jpg"), T1 + i as i64 * 600);
+        }
+        drop(conn);
+
+        let events = cluster_events(&db).unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn burst_detection_groups_rapid_shots() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        // 5 shots within 1s of each other, same camera
+        for i in 0..5i64 {
+            conn.execute(
+                "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                    fingerprint, updated_at, camera_model)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, 0, 'Sony A7')",
+                params![root, format!("{i}.jpg"), format!("{i}.jpg"),
+                        format!("/tmp/{i}.jpg"), (T1 + i) * 1_000_000_000, format!("fp{i}")],
+            ).unwrap();
+        }
+        drop(conn);
+
+        let bursts = find_bursts(&db).unwrap();
+        assert_eq!(bursts.len(), 1);
+        assert_eq!(bursts[0].member_ids.len(), 5);
+    }
+
+    #[test]
+    fn haversine_same_point_is_zero() {
+        assert!(haversine_m(48.8566, 2.3522, 48.8566, 2.3522).abs() < 1e-6);
+    }
+
+    #[test]
+    fn haversine_paris_london_approx() {
+        let d = haversine_m(48.8566, 2.3522, 51.5074, -0.1278);
+        // Real distance ~343 km, allow 5% tolerance
+        assert!(d > 320_000.0 && d < 360_000.0, "distance was {d}");
+    }
+
+    #[test]
+    fn epoch_to_date_str_known() {
+        // 2023-01-15: 1673740800 / 86400 = 19367 days from epoch
+        let ts = 1_673_740_800i64;
+        let s = epoch_to_date_str(ts);
+        assert_eq!(s, "2023-01-15");
+    }
+
+    #[test]
+    fn dedup_keep_largest_keeps_bigger() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        // Two files with the same fingerprint, different sizes
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at)
+             VALUES (?1, 'small.jpg', 'small.jpg', '/tmp/small.jpg', 1000000000000, 100, 'dup', 0)",
+            params![root],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at)
+             VALUES (?1, 'large.jpg', 'large.jpg', '/tmp/large.jpg', 1000000001000, 500, 'dup', 0)",
+            params![root],
+        ).unwrap();
+        drop(conn);
+
+        set_dedup_policy(&db, DedupStrategy::KeepLargest).unwrap();
+        let deleted = apply_dedup_policy(&db).unwrap();
+        assert_eq!(deleted, 1);
+
+        let conn2 = Connection::open(&db).unwrap();
+        let remaining: i64 = conn2.query_row(
+            "SELECT COUNT(*) FROM files WHERE deleted_at IS NULL AND fingerprint = 'dup'",
+            [],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(remaining, 1);
+        let keeper: String = conn2.query_row(
+            "SELECT filename FROM files WHERE deleted_at IS NULL AND fingerprint = 'dup'",
+            [],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(keeper, "large.jpg");
+    }
+
+    #[test]
+    fn generate_year_review_creates_album() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        // Insert 3 photos in 2023
+        for i in 1i64..=3 {
+            conn.execute(
+                "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                    fingerprint, updated_at, media_type, confidence)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, 0, 'photo', 0.9)",
+                params![root, format!("{i}.jpg"), format!("{i}.jpg"), format!("/tmp/{i}.jpg"),
+                        (1672574400i64 + i * 2592000) * 1_000_000_000, format!("fp{i}")],
+            ).unwrap();
+        }
+        drop(conn);
+
+        let album_id = generate_year_review(&db, 2023).unwrap();
+        assert!(album_id > 0);
+
+        let conn2 = Connection::open(&db).unwrap();
+        let name: String = conn2.query_row(
+            "SELECT name FROM albums WHERE id = ?1",
+            params![album_id],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(name, "Year in Review — 2023");
+    }
+}

--- a/sherlock/desktop/src-tauri/src/config.rs
+++ b/sherlock/desktop/src-tauri/src/config.rs
@@ -39,11 +39,29 @@ impl AppPaths {
 }
 
 pub fn resolve_paths() -> AppResult<AppPaths> {
-    let base_dir = match env::var(DATA_DIR_ENV) {
-        Ok(value) if !value.trim().is_empty() => PathBuf::from(value),
-        _ => default_base_dir()?,
-    };
+    // Read portable_root from user_config (if present, valid, and non-empty).
+    let portable_root = portable_root_from_user_config();
+    resolve_paths_for_root(portable_root.as_deref())
+}
 
+/// Resolve paths, optionally placing the catalog under `<portable_root>/.frank_sherlock/`.
+/// Precedence:
+///   1. `portable_root.join(".frank_sherlock")` if provided.
+///   2. `DATA_DIR_ENV` if set and non-empty.
+///   3. `default_base_dir()`.
+pub fn resolve_paths_for_root(portable_root: Option<&Path>) -> AppResult<AppPaths> {
+    let base_dir = if let Some(root) = portable_root {
+        root.join(".frank_sherlock")
+    } else {
+        match env::var(DATA_DIR_ENV) {
+            Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
+            _ => default_base_dir()?,
+        }
+    };
+    build_paths(base_dir)
+}
+
+fn build_paths(base_dir: PathBuf) -> AppResult<AppPaths> {
     let db_dir = base_dir.join("db");
     let cache_dir = base_dir.join("cache");
     let classification_cache_dir = cache_dir.join("classifications");
@@ -68,6 +86,24 @@ pub fn resolve_paths() -> AppResult<AppPaths> {
         models_dir,
         face_crops_dir,
     })
+}
+
+/// Read the `portableRoot` field from user_config. Returns `None` if unset,
+/// empty, malformed, or points to a path that does not exist.
+fn portable_root_from_user_config() -> Option<PathBuf> {
+    let cfg = load_user_config().ok()?;
+    let raw = cfg.get("portableRoot")?.as_str()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let p = PathBuf::from(raw);
+    if !p.is_dir() {
+        eprintln!(
+            "portableRoot in user_config does not exist or is not a directory: {raw}"
+        );
+        return None;
+    }
+    Some(p)
 }
 
 pub fn prepare_dirs(paths: &AppPaths) -> AppResult<()> {
@@ -255,6 +291,45 @@ mod tests {
         std::fs::write(&file, "hello").expect("write");
         let err = expand_and_canonicalize(file.to_str().unwrap());
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn resolve_paths_portable_uses_root_subdir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        env::remove_var(DATA_DIR_ENV);
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("MyDrive");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let paths = resolve_paths_for_root(Some(&root)).unwrap();
+        assert!(paths.base_dir.starts_with(&root), "base_dir {:?} should start with {:?}", paths.base_dir, root);
+        assert_eq!(paths.base_dir.file_name().unwrap(), ".frank_sherlock");
+        assert!(paths.db_file.starts_with(&paths.base_dir));
+        assert!(paths.thumbnails_dir.starts_with(&paths.base_dir));
+    }
+
+    #[test]
+    fn resolve_paths_portable_precedence_over_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let env_dir = tempfile::tempdir().unwrap();
+        env::set_var(DATA_DIR_ENV, env_dir.path().join("env_data").as_os_str());
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("Portable");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let paths = resolve_paths_for_root(Some(&root)).unwrap();
+        assert!(paths.base_dir.starts_with(&root), "portable_root must win over DATA_DIR_ENV");
+        env::remove_var(DATA_DIR_ENV);
+    }
+
+    #[test]
+    fn resolve_paths_portable_none_falls_back_to_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let env_dir = tempfile::tempdir().unwrap();
+        env::set_var(DATA_DIR_ENV, env_dir.path().join("env_data").as_os_str());
+        let paths = resolve_paths_for_root(None).unwrap();
+        assert!(paths.base_dir.starts_with(env_dir.path()));
+        env::remove_var(DATA_DIR_ENV);
     }
 
     #[test]

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -292,6 +292,19 @@ fn run_migrations(conn: &mut Connection) -> AppResult<()> {
             CREATE INDEX IF NOT EXISTS idx_people_name ON people(name COLLATE NOCASE);
             "#,
         ),
+        // Migration 13: EXIF camera/lens/ISO/shutter/aperture/time_of_day for filtering
+        M::up(
+            r#"
+            ALTER TABLE files ADD COLUMN camera_model TEXT NOT NULL DEFAULT '';
+            ALTER TABLE files ADD COLUMN lens_model TEXT NOT NULL DEFAULT '';
+            ALTER TABLE files ADD COLUMN iso INTEGER;
+            ALTER TABLE files ADD COLUMN shutter_speed REAL;
+            ALTER TABLE files ADD COLUMN aperture REAL;
+            ALTER TABLE files ADD COLUMN time_of_day TEXT NOT NULL DEFAULT '';
+            CREATE INDEX IF NOT EXISTS idx_files_camera_model ON files(camera_model);
+            CREATE INDEX IF NOT EXISTS idx_files_time_of_day ON files(time_of_day);
+            "#,
+        ),
     ]);
 
     migrations
@@ -856,13 +869,15 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             media_type, description, extracted_text, canonical_mentions,
             confidence, lang_hint, mtime_ns, size_bytes, fingerprint,
             scan_marker, updated_at, deleted_at, location_text, dhash,
-            duration_secs, video_width, video_height, video_codec, audio_codec
+            duration_secs, video_width, video_height, video_codec, audio_codec,
+            camera_model, lens_model, iso, shutter_speed, aperture, time_of_day
         ) VALUES (
             ?1, ?2, ?3, ?4,
             ?5, ?6, ?7, ?8,
             ?9, ?10, ?11, ?12, ?13,
             ?14, ?15, NULL, ?16, ?17,
-            ?18, ?19, ?20, ?21, ?22
+            ?18, ?19, ?20, ?21, ?22,
+            ?23, ?24, ?25, ?26, ?27, ?28
         )
         ON CONFLICT(root_id, rel_path) DO UPDATE SET
             filename = excluded.filename,
@@ -885,7 +900,13 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             video_width = excluded.video_width,
             video_height = excluded.video_height,
             video_codec = excluded.video_codec,
-            audio_codec = excluded.audio_codec
+            audio_codec = excluded.audio_codec,
+            camera_model = CASE WHEN excluded.camera_model != '' THEN excluded.camera_model ELSE files.camera_model END,
+            lens_model = CASE WHEN excluded.lens_model != '' THEN excluded.lens_model ELSE files.lens_model END,
+            iso = COALESCE(excluded.iso, files.iso),
+            shutter_speed = COALESCE(excluded.shutter_speed, files.shutter_speed),
+            aperture = COALESCE(excluded.aperture, files.aperture),
+            time_of_day = CASE WHEN excluded.time_of_day != '' THEN excluded.time_of_day ELSE files.time_of_day END
         "#,
         params![
             record.root_id,
@@ -910,6 +931,12 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             record.video_height,
             record.video_codec,
             record.audio_codec,
+            record.camera_model,
+            record.lens_model,
+            record.iso,
+            record.shutter_speed,
+            record.aperture,
+            record.time_of_day,
         ],
     )?;
 
@@ -1679,6 +1706,19 @@ fn search_images_normalized(
         bind_values.push(Value::Text(format!("%{pname}%")));
     }
 
+    if let Some(ref camera) = parsed.camera_model {
+        where_clauses.push("f.camera_model = ?".to_string());
+        bind_values.push(Value::Text(camera.clone()));
+    }
+    if let Some(ref lens) = parsed.lens_model {
+        where_clauses.push("f.lens_model = ?".to_string());
+        bind_values.push(Value::Text(lens.clone()));
+    }
+    if let Some(ref tod) = parsed.time_of_day {
+        where_clauses.push("f.time_of_day = ?".to_string());
+        bind_values.push(Value::Text(tod.clone()));
+    }
+
     let media_types = normalize_media_types(&request.media_types);
     if !media_types.is_empty() {
         let placeholders = vec!["?"; media_types.len()].join(", ");
@@ -1826,6 +1866,19 @@ fn search_like_fallback(
         );
         where_clauses.push("pp.name LIKE ? COLLATE NOCASE".to_string());
         bind_values.push(Value::Text(format!("%{pname}%")));
+    }
+
+    if let Some(ref camera) = parsed.camera_model {
+        where_clauses.push("f.camera_model = ?".to_string());
+        bind_values.push(Value::Text(camera.clone()));
+    }
+    if let Some(ref lens) = parsed.lens_model {
+        where_clauses.push("f.lens_model = ?".to_string());
+        bind_values.push(Value::Text(lens.clone()));
+    }
+    if let Some(ref tod) = parsed.time_of_day {
+        where_clauses.push("f.time_of_day = ?".to_string());
+        bind_values.push(Value::Text(tod.clone()));
     }
 
     let media_types = normalize_media_types(&request.media_types);
@@ -3933,6 +3986,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         }
     }
 
@@ -3974,6 +4033,12 @@ mod tests {
                 video_height: None,
                 video_codec: None,
                 audio_codec: None,
+                camera_model: String::new(),
+                lens_model: String::new(),
+                iso: None,
+                shutter_speed: None,
+                aperture: None,
+                time_of_day: String::new(),
             };
             upsert_file_record(&db_path, &rec).expect("upsert");
         }
@@ -4023,6 +4088,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4065,6 +4136,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4110,6 +4187,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         touch_file_scan_marker(&db_path, root_id, "a.jpg", 2).expect("touch");
@@ -4154,6 +4237,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         let files = load_existing_files(&db_path, root_id).expect("load");
@@ -4189,6 +4278,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         mark_missing_as_deleted(&db_path, root_id, 99).expect("delete");
@@ -4601,6 +4696,12 @@ mod tests {
                 video_height: None,
                 video_codec: None,
                 audio_codec: None,
+                camera_model: String::new(),
+                lens_model: String::new(),
+                iso: None,
+                shutter_speed: None,
+                aperture: None,
+                time_of_day: String::new(),
             };
             upsert_file_record(db_path, &rec).expect("upsert");
         }
@@ -4667,11 +4768,11 @@ mod tests {
         init_database(&db_path).expect("init");
 
         let conn = open_conn(&db_path).expect("open");
-        // Verify user_version is set (13 migrations applied → version 13)
+        // Verify user_version is set (14 migrations applied → version 14)
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .expect("user_version");
-        assert_eq!(version, 13);
+        assert_eq!(version, 14);
 
         // Verify all tables exist
         let tables: Vec<String> = {
@@ -4715,8 +4816,8 @@ mod tests {
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .expect("user_version");
-        // We have 13 migrations (indices 0..12), so user_version should be 13
-        assert_eq!(version, 13);
+        // We have 14 migrations (indices 0..13), so user_version should be 14
+        assert_eq!(version, 14);
     }
 
     #[test]
@@ -5663,6 +5764,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -5689,6 +5796,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         upsert_file_record(&db_path, &rec2).expect("upsert");
 

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -960,7 +960,7 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             scan_marker, updated_at, deleted_at, location_text, dhash,
             duration_secs, video_width, video_height, video_codec, audio_codec,
             camera_model, lens_model, iso, shutter_speed, aperture, time_of_day,
-            blur_score
+            blur_score, dominant_color, qr_codes
         ) VALUES (
             ?1, ?2, ?3, ?4,
             ?5, ?6, ?7, ?8,
@@ -968,7 +968,7 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             ?14, ?15, NULL, ?16, ?17,
             ?18, ?19, ?20, ?21, ?22,
             ?23, ?24, ?25, ?26, ?27, ?28,
-            ?29
+            ?29, ?30, ?31
         )
         ON CONFLICT(root_id, rel_path) DO UPDATE SET
             filename = excluded.filename,
@@ -998,7 +998,9 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             shutter_speed = COALESCE(excluded.shutter_speed, files.shutter_speed),
             aperture = COALESCE(excluded.aperture, files.aperture),
             time_of_day = CASE WHEN excluded.time_of_day != '' THEN excluded.time_of_day ELSE files.time_of_day END,
-            blur_score = COALESCE(excluded.blur_score, files.blur_score)
+            blur_score = COALESCE(excluded.blur_score, files.blur_score),
+            dominant_color = COALESCE(excluded.dominant_color, files.dominant_color),
+            qr_codes = CASE WHEN excluded.qr_codes != '' THEN excluded.qr_codes ELSE files.qr_codes END
         "#,
         params![
             record.root_id,
@@ -1030,6 +1032,8 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             record.aperture,
             record.time_of_day,
             record.blur_score,
+            record.dominant_color,
+            record.qr_codes,
         ],
     )?;
 
@@ -1822,6 +1826,21 @@ fn search_images_normalized(
             where_clauses.push("(f.blur_score IS NULL OR f.blur_score >= 100.0)".to_string());
         }
     }
+    if let Some(hex) = parsed.color_hex {
+        let r = ((hex >> 16) & 255) as i64;
+        let g = ((hex >> 8) & 255) as i64;
+        let b = (hex & 255) as i64;
+        where_clauses.push(
+            "f.dominant_color IS NOT NULL AND \
+             ABS(((f.dominant_color >> 16) & 255) - ?) + \
+             ABS(((f.dominant_color >> 8) & 255) - ?) + \
+             ABS((f.dominant_color & 255) - ?) < 120"
+                .to_string(),
+        );
+        bind_values.push(Value::Integer(r));
+        bind_values.push(Value::Integer(g));
+        bind_values.push(Value::Integer(b));
+    }
 
     let media_types = normalize_media_types(&request.media_types);
     if !media_types.is_empty() {
@@ -1994,6 +2013,21 @@ fn search_like_fallback(
         } else {
             where_clauses.push("(f.blur_score IS NULL OR f.blur_score >= 100.0)".to_string());
         }
+    }
+    if let Some(hex) = parsed.color_hex {
+        let r = ((hex >> 16) & 255) as i64;
+        let g = ((hex >> 8) & 255) as i64;
+        let b = (hex & 255) as i64;
+        where_clauses.push(
+            "f.dominant_color IS NOT NULL AND \
+             ABS(((f.dominant_color >> 16) & 255) - ?) + \
+             ABS(((f.dominant_color >> 8) & 255) - ?) + \
+             ABS((f.dominant_color & 255) - ?) < 120"
+                .to_string(),
+        );
+        bind_values.push(Value::Integer(r));
+        bind_values.push(Value::Integer(g));
+        bind_values.push(Value::Integer(b));
     }
 
     let media_types = normalize_media_types(&request.media_types);
@@ -4108,6 +4142,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         }
     }
 
@@ -4156,6 +4192,8 @@ mod tests {
                 aperture: None,
                 time_of_day: String::new(),
                 blur_score: None,
+                dominant_color: None,
+                qr_codes: String::new(),
             };
             upsert_file_record(&db_path, &rec).expect("upsert");
         }
@@ -4212,6 +4250,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4261,6 +4301,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4313,6 +4355,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         touch_file_scan_marker(&db_path, root_id, "a.jpg", 2).expect("touch");
@@ -4364,6 +4408,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         let files = load_existing_files(&db_path, root_id).expect("load");
@@ -4406,6 +4452,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         mark_missing_as_deleted(&db_path, root_id, 99).expect("delete");
@@ -4825,6 +4873,8 @@ mod tests {
                 aperture: None,
                 time_of_day: String::new(),
                 blur_score: None,
+                dominant_color: None,
+                qr_codes: String::new(),
             };
             upsert_file_record(db_path, &rec).expect("upsert");
         }
@@ -5894,6 +5944,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -5927,6 +5979,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         upsert_file_record(&db_path, &rec2).expect("upsert");
 
@@ -7426,5 +7480,40 @@ mod tests {
             )
             .unwrap();
         assert_eq!(abs, "C:\\somewhere\\foo.jpg");
+    }
+
+    // -----------------------------------------------------------------------
+    // color_hex filter test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_search_color_hex_filter() {
+        let (_dir, db_path) = test_db_path();
+        init_database(&db_path).expect("init");
+        let root_id = upsert_root(&db_path, "/tmp/demo").expect("root");
+
+        // Red-ish photo: dominant_color = 0x00CC2211 (R=204, G=34, B=17)
+        let mut rec_red = sample_record(root_id, "red.jpg", "fp-red");
+        rec_red.dominant_color = Some(0x00CC2211_i64);
+        upsert_file_record(&db_path, &rec_red).expect("upsert red");
+
+        // Blue-ish photo: dominant_color = 0x00112299 (R=17, G=34, B=153)
+        let mut rec_blue = sample_record(root_id, "blue.jpg", "fp-blue");
+        rec_blue.dominant_color = Some(0x00112299_i64);
+        upsert_file_record(&db_path, &rec_blue).expect("upsert blue");
+
+        // No color: no dominant_color
+        let rec_none = sample_record(root_id, "nocolor.jpg", "fp-nocolor");
+        upsert_file_record(&db_path, &rec_none).expect("upsert nocolor");
+
+        // Query color:red (#FF0000) — Manhattan distance to red.jpg = |204-255|+|34-0|+|17-0| = 51+34+17 = 102 < 120
+        // Manhattan distance to blue.jpg = |17-255|+|34-0|+|153-0| = 238+34+153 = 425 ≥ 120
+        let req = SearchRequest {
+            query: "color:#FF0000".to_string(),
+            ..SearchRequest::default()
+        };
+        let res = search_images(&db_path, &req).expect("search color");
+        assert_eq!(res.total, 1);
+        assert_eq!(res.items[0].rel_path, "red.jpg");
     }
 }

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -3791,6 +3791,90 @@ fn build_exact_group(fingerprint: &str, files: &mut [DuplicateFile]) -> Duplicat
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemapReport {
+    pub roots_updated: usize,
+    pub files_updated: usize,
+    pub scan_jobs_updated: usize,
+}
+
+impl Default for RemapReport {
+    fn default() -> Self {
+        Self {
+            roots_updated: 0,
+            files_updated: 0,
+            scan_jobs_updated: 0,
+        }
+    }
+}
+
+/// Rewrite `root_path` and all dependent `abs_path` columns when a root
+/// moves (drive letter change, directory rename). Both paths are compared
+/// and stored verbatim — the caller is expected to canonicalize.
+///
+/// Fails if `new_root_path` collides with another existing root.
+pub fn remap_root(
+    db_path: &Path,
+    old_root_path: &str,
+    new_root_path: &str,
+) -> AppResult<RemapReport> {
+    if old_root_path == new_root_path {
+        return Ok(RemapReport::default());
+    }
+    let mut conn = Connection::open(db_path)?;
+    let tx = conn.transaction()?;
+
+    // Collision check.
+    let collides: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM roots WHERE root_path = ?1)",
+        params![new_root_path],
+        |r| r.get::<_, i64>(0).map(|v| v != 0),
+    )?;
+    if collides {
+        return Err(AppError::Config(format!(
+            "remap target already exists as a root: {new_root_path}"
+        )));
+    }
+
+    // Find the root id.
+    let root_id: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM roots WHERE root_path = ?1",
+            params![old_root_path],
+            |r| r.get(0),
+        )
+        .ok();
+    let Some(root_id) = root_id else {
+        return Err(AppError::Config(format!("no such root: {old_root_path}")));
+    };
+
+    let roots_updated = tx.execute(
+        "UPDATE roots SET root_path = ?1 WHERE id = ?2",
+        params![new_root_path, root_id],
+    )?;
+
+    // Rewrite only the prefix of abs_path to avoid clobbering substrings that
+    // match elsewhere in the string.
+    let files_updated = tx.execute(
+        "UPDATE files SET abs_path = ?1 || substr(abs_path, length(?2) + 1)
+         WHERE root_id = ?3 AND substr(abs_path, 1, length(?2)) = ?2",
+        params![new_root_path, old_root_path, root_id],
+    )?;
+
+    let scan_jobs_updated = tx.execute(
+        "UPDATE scan_jobs SET root_path = ?1 WHERE root_id = ?2",
+        params![new_root_path, root_id],
+    )?;
+
+    tx.commit()?;
+    Ok(RemapReport {
+        roots_updated,
+        files_updated,
+        scan_jobs_updated,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -6869,5 +6953,57 @@ mod tests {
             |r| r.get(0),
         )
         .expect("file id")
+    }
+
+    #[test]
+    fn remap_root_updates_root_and_abs_paths() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+
+        // Seed a root with one file.
+        let root_id = upsert_root(&db_path, "D:\\Photos").unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, 'fp', 0)",
+            rusqlite::params![root_id, "a/b.jpg", "b.jpg", "D:\\Photos\\a\\b.jpg"],
+        ).unwrap();
+        drop(conn);
+
+        // Act.
+        let changed = remap_root(&db_path, "D:\\Photos", "E:\\Photos").unwrap();
+        assert_eq!(changed.roots_updated, 1);
+        assert_eq!(changed.files_updated, 1);
+
+        // Assert.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let root_path: String = conn.query_row(
+            "SELECT root_path FROM roots WHERE id = ?1",
+            rusqlite::params![root_id],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(root_path, "E:\\Photos");
+
+        let abs: String = conn.query_row(
+            "SELECT abs_path FROM files WHERE root_id = ?1",
+            rusqlite::params![root_id],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(abs, "E:\\Photos\\a\\b.jpg");
+    }
+
+    #[test]
+    fn remap_root_rejects_collision_with_existing_root() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+        upsert_root(&db_path, "D:\\A").unwrap();
+        upsert_root(&db_path, "D:\\B").unwrap();
+
+        let err = remap_root(&db_path, "D:\\A", "D:\\B");
+        assert!(err.is_err(), "remap onto another existing root must fail");
     }
 }

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -9,7 +9,7 @@ use crate::error::{AppError, AppResult};
 use crate::models::{
     Album, DbStats, DuplicateFile, DuplicateGroup, DuplicatesResponse, ExistingFile, FileMetadata,
     FileProperties, FileRecordUpsert, HealthCheckOutcome, ParsedQuery, PdfPassword,
-    ProtectedPdfInfo, PurgeResult, RootInfo, ScanJobState, ScanJobStatus, SearchItem,
+    ProtectedPdfInfo, PurgeResult, RootInfo, SavedSearch, ScanJobState, ScanJobStatus, SearchItem,
     SearchRequest, SearchResponse, SmartFolder, SortField, SortOrder, SubdirEntry, TagRule,
 };
 use crate::query_parser::parse_query;
@@ -2592,6 +2592,70 @@ pub fn get_enabled_tag_rules(db_path: &Path) -> AppResult<Vec<TagRule>> {
         rules.push(row?);
     }
     Ok(rules)
+}
+
+// ── Saved Searches ───────────────────────────────────────────────────
+
+pub fn list_saved_searches(db_path: &Path) -> AppResult<Vec<SavedSearch>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, name, query, notify, last_match_id, last_checked_at
+         FROM saved_searches ORDER BY id",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(SavedSearch {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            query: row.get(2)?,
+            notify: row.get::<_, i64>(3)? != 0,
+            last_match_id: row.get(4)?,
+            last_checked_at: row.get(5)?,
+        })
+    })?;
+    let mut searches = Vec::new();
+    for row in rows {
+        searches.push(row?);
+    }
+    Ok(searches)
+}
+
+pub fn create_saved_search(db_path: &Path, name: &str, query: &str) -> AppResult<SavedSearch> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "INSERT INTO saved_searches (name, query) VALUES (?1, ?2)",
+        params![name, query],
+    )?;
+    let id = conn.last_insert_rowid();
+    Ok(SavedSearch {
+        id,
+        name: name.to_string(),
+        query: query.to_string(),
+        notify: false,
+        last_match_id: 0,
+        last_checked_at: 0,
+    })
+}
+
+pub fn delete_saved_search(db_path: &Path, search_id: i64) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "DELETE FROM saved_searches WHERE id = ?1",
+        params![search_id],
+    )?;
+    Ok(())
+}
+
+pub fn set_saved_search_notify(
+    db_path: &Path,
+    search_id: i64,
+    notify: bool,
+) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "UPDATE saved_searches SET notify = ?1 WHERE id = ?2",
+        params![notify as i64, search_id],
+    )?;
+    Ok(())
 }
 
 // ── PDF Passwords ───────────────────────────────────────────────────
@@ -7635,6 +7699,38 @@ mod tests {
     // -----------------------------------------------------------------------
     // Tag rules tests
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Saved searches tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_saved_searches_crud() {
+        let (_dir, db_path) = test_db_path();
+        init_database(&db_path).expect("init");
+
+        // Empty by default
+        assert!(list_saved_searches(&db_path).expect("list").is_empty());
+
+        // Create
+        let s = create_saved_search(&db_path, "Vacation", "vacation beach").expect("create");
+        assert_eq!(s.name, "Vacation");
+        assert_eq!(s.query, "vacation beach");
+        assert!(!s.notify);
+
+        // List
+        let all = list_saved_searches(&db_path).expect("list one");
+        assert_eq!(all.len(), 1);
+
+        // Toggle notify
+        set_saved_search_notify(&db_path, s.id, true).expect("notify on");
+        let updated = list_saved_searches(&db_path).expect("list updated");
+        assert!(updated[0].notify);
+
+        // Delete
+        delete_saved_search(&db_path, s.id).expect("delete");
+        assert!(list_saved_searches(&db_path).expect("after delete").is_empty());
+    }
 
     #[test]
     fn test_tag_rules_crud() {

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -305,6 +305,95 @@ fn run_migrations(conn: &mut Connection) -> AppResult<()> {
             CREATE INDEX IF NOT EXISTS idx_files_time_of_day ON files(time_of_day);
             "#,
         ),
+        // Migration 14: Events + event_files tables for photo-session clustering
+        M::up(
+            r#"
+            CREATE TABLE IF NOT EXISTS events (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL DEFAULT '',
+                started_at  INTEGER NOT NULL DEFAULT 0,
+                ended_at    INTEGER NOT NULL DEFAULT 0,
+                centroid_lat REAL,
+                centroid_lon REAL,
+                cover_file_id INTEGER,
+                trip_id     INTEGER
+            );
+            CREATE TABLE IF NOT EXISTS event_files (
+                event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+                file_id  INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+                UNIQUE(event_id, file_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_event_files_file_id ON event_files(file_id);
+            "#,
+        ),
+        // Migration 15: Trips table
+        M::up(
+            r#"
+            CREATE TABLE IF NOT EXISTS trips (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL DEFAULT '',
+                started_at  INTEGER NOT NULL DEFAULT 0,
+                ended_at    INTEGER NOT NULL DEFAULT 0,
+                event_count INTEGER NOT NULL DEFAULT 0,
+                cover_file_id INTEGER
+            );
+            "#,
+        ),
+        // Migration 16: blur_score column + shot_kind column on files
+        M::up(
+            r#"
+            ALTER TABLE files ADD COLUMN blur_score REAL;
+            ALTER TABLE files ADD COLUMN shot_kind TEXT NOT NULL DEFAULT '';
+            CREATE INDEX IF NOT EXISTS idx_files_shot_kind ON files(shot_kind);
+            "#,
+        ),
+        // Migration 17: dominant_color column (packed 0xRRGGBB)
+        M::up(
+            r#"
+            ALTER TABLE files ADD COLUMN dominant_color INTEGER;
+            "#,
+        ),
+        // Migration 18: dedup_policy table + qr_codes column
+        M::up(
+            r#"
+            CREATE TABLE IF NOT EXISTS dedup_policy (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                strategy TEXT NOT NULL CHECK(strategy IN ('keep_largest','keep_oldest','keep_in_album')),
+                enabled  INTEGER NOT NULL DEFAULT 1
+            );
+            ALTER TABLE files ADD COLUMN qr_codes TEXT NOT NULL DEFAULT '';
+            "#,
+        ),
+        // Migration 19: saved_searches for alerts
+        M::up(
+            r#"
+            CREATE TABLE IF NOT EXISTS saved_searches (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                name            TEXT NOT NULL DEFAULT '',
+                query           TEXT NOT NULL DEFAULT '',
+                notify          INTEGER NOT NULL DEFAULT 0,
+                last_match_id   INTEGER NOT NULL DEFAULT 0,
+                last_checked_at INTEGER NOT NULL DEFAULT 0
+            );
+            "#,
+        ),
+        // Migration 20: tag_rules for path-pattern auto-tagging
+        M::up(
+            r#"
+            CREATE TABLE IF NOT EXISTS tag_rules (
+                id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                pattern TEXT NOT NULL DEFAULT '',
+                tag     TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1
+            );
+            "#,
+        ),
+        // Migration 21: album tag inheritance column
+        M::up(
+            r#"
+            ALTER TABLE albums ADD COLUMN tag TEXT NOT NULL DEFAULT '';
+            "#,
+        ),
     ]);
 
     migrations
@@ -870,14 +959,16 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             confidence, lang_hint, mtime_ns, size_bytes, fingerprint,
             scan_marker, updated_at, deleted_at, location_text, dhash,
             duration_secs, video_width, video_height, video_codec, audio_codec,
-            camera_model, lens_model, iso, shutter_speed, aperture, time_of_day
+            camera_model, lens_model, iso, shutter_speed, aperture, time_of_day,
+            blur_score
         ) VALUES (
             ?1, ?2, ?3, ?4,
             ?5, ?6, ?7, ?8,
             ?9, ?10, ?11, ?12, ?13,
             ?14, ?15, NULL, ?16, ?17,
             ?18, ?19, ?20, ?21, ?22,
-            ?23, ?24, ?25, ?26, ?27, ?28
+            ?23, ?24, ?25, ?26, ?27, ?28,
+            ?29
         )
         ON CONFLICT(root_id, rel_path) DO UPDATE SET
             filename = excluded.filename,
@@ -906,7 +997,8 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             iso = COALESCE(excluded.iso, files.iso),
             shutter_speed = COALESCE(excluded.shutter_speed, files.shutter_speed),
             aperture = COALESCE(excluded.aperture, files.aperture),
-            time_of_day = CASE WHEN excluded.time_of_day != '' THEN excluded.time_of_day ELSE files.time_of_day END
+            time_of_day = CASE WHEN excluded.time_of_day != '' THEN excluded.time_of_day ELSE files.time_of_day END,
+            blur_score = COALESCE(excluded.blur_score, files.blur_score)
         "#,
         params![
             record.root_id,
@@ -937,6 +1029,7 @@ pub fn upsert_file_record(db_path: &Path, record: &FileRecordUpsert) -> AppResul
             record.shutter_speed,
             record.aperture,
             record.time_of_day,
+            record.blur_score,
         ],
     )?;
 
@@ -1718,6 +1811,17 @@ fn search_images_normalized(
         where_clauses.push("f.time_of_day = ?".to_string());
         bind_values.push(Value::Text(tod.clone()));
     }
+    if let Some(ref sk) = parsed.shot_kind {
+        where_clauses.push("f.shot_kind = ?".to_string());
+        bind_values.push(Value::Text(sk.clone()));
+    }
+    if let Some(is_blurry) = parsed.blur {
+        if is_blurry {
+            where_clauses.push("f.blur_score IS NOT NULL AND f.blur_score < 100.0".to_string());
+        } else {
+            where_clauses.push("(f.blur_score IS NULL OR f.blur_score >= 100.0)".to_string());
+        }
+    }
 
     let media_types = normalize_media_types(&request.media_types);
     if !media_types.is_empty() {
@@ -1879,6 +1983,17 @@ fn search_like_fallback(
     if let Some(ref tod) = parsed.time_of_day {
         where_clauses.push("f.time_of_day = ?".to_string());
         bind_values.push(Value::Text(tod.clone()));
+    }
+    if let Some(ref sk) = parsed.shot_kind {
+        where_clauses.push("f.shot_kind = ?".to_string());
+        bind_values.push(Value::Text(sk.clone()));
+    }
+    if let Some(is_blurry) = parsed.blur {
+        if is_blurry {
+            where_clauses.push("f.blur_score IS NOT NULL AND f.blur_score < 100.0".to_string());
+        } else {
+            where_clauses.push("(f.blur_score IS NULL OR f.blur_score >= 100.0)".to_string());
+        }
     }
 
     let media_types = normalize_media_types(&request.media_types);
@@ -3992,6 +4107,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         }
     }
 
@@ -4039,6 +4155,7 @@ mod tests {
                 shutter_speed: None,
                 aperture: None,
                 time_of_day: String::new(),
+                blur_score: None,
             };
             upsert_file_record(&db_path, &rec).expect("upsert");
         }
@@ -4094,6 +4211,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4142,6 +4260,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -4193,6 +4312,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         touch_file_scan_marker(&db_path, root_id, "a.jpg", 2).expect("touch");
@@ -4243,6 +4363,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         let files = load_existing_files(&db_path, root_id).expect("load");
@@ -4284,6 +4405,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
         mark_missing_as_deleted(&db_path, root_id, 99).expect("delete");
@@ -4702,6 +4824,7 @@ mod tests {
                 shutter_speed: None,
                 aperture: None,
                 time_of_day: String::new(),
+                blur_score: None,
             };
             upsert_file_record(db_path, &rec).expect("upsert");
         }
@@ -4768,11 +4891,11 @@ mod tests {
         init_database(&db_path).expect("init");
 
         let conn = open_conn(&db_path).expect("open");
-        // Verify user_version is set (14 migrations applied → version 14)
+        // Verify user_version is set (22 migrations applied → version 22)
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .expect("user_version");
-        assert_eq!(version, 14);
+        assert_eq!(version, 22);
 
         // Verify all tables exist
         let tables: Vec<String> = {
@@ -4816,8 +4939,8 @@ mod tests {
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |r| r.get(0))
             .expect("user_version");
-        // We have 14 migrations (indices 0..13), so user_version should be 14
-        assert_eq!(version, 14);
+        // We have 22 migrations (indices 0..21), so user_version should be 22
+        assert_eq!(version, 22);
     }
 
     #[test]
@@ -5770,6 +5893,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec).expect("upsert");
 
@@ -5802,6 +5926,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         upsert_file_record(&db_path, &rec2).expect("upsert");
 

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -3791,7 +3791,7 @@ fn build_exact_group(fingerprint: &str, files: &mut [DuplicateFile]) -> Duplicat
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemapReport {
     pub roots_updated: usize,
@@ -3799,21 +3799,19 @@ pub struct RemapReport {
     pub scan_jobs_updated: usize,
 }
 
-impl Default for RemapReport {
-    fn default() -> Self {
-        Self {
-            roots_updated: 0,
-            files_updated: 0,
-            scan_jobs_updated: 0,
-        }
-    }
-}
-
 /// Rewrite `root_path` and all dependent `abs_path` columns when a root
-/// moves (drive letter change, directory rename). Both paths are compared
-/// and stored verbatim — the caller is expected to canonicalize.
+/// moves (drive letter change, directory rename).
 ///
-/// Fails if `new_root_path` collides with another existing root.
+/// Paths are compared byte-for-byte; callers must canonicalize (trailing
+/// separator, case) before calling.
+///
+/// All `scan_jobs` rows for the root are rewritten, including historical
+/// completed jobs, so path-keyed lookups continue to work after the move.
+///
+/// Fails if `new_root_path` collides with another existing root, if the
+/// old root is not found, or if the prefix rewrite would leave some files
+/// with stale paths (indicating caller/data drift — the whole transaction
+/// is rolled back).
 pub fn remap_root(
     db_path: &Path,
     old_root_path: &str,
@@ -3822,8 +3820,10 @@ pub fn remap_root(
     if old_root_path == new_root_path {
         return Ok(RemapReport::default());
     }
-    let mut conn = Connection::open(db_path)?;
-    let tx = conn.transaction()?;
+    let mut conn = open_conn(db_path)?;
+    // IMMEDIATE locks the database for writes up front, avoiding a TOCTOU
+    // race between the collision check and the UPDATE.
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
     // Collision check.
     let collides: bool = tx.query_row(
@@ -3832,21 +3832,27 @@ pub fn remap_root(
         |r| r.get::<_, i64>(0).map(|v| v != 0),
     )?;
     if collides {
-        return Err(AppError::Config(format!(
+        return Err(AppError::InvalidPath(format!(
             "remap target already exists as a root: {new_root_path}"
         )));
     }
 
-    // Find the root id.
-    let root_id: Option<i64> = tx
-        .query_row(
-            "SELECT id FROM roots WHERE root_path = ?1",
-            params![old_root_path],
-            |r| r.get(0),
-        )
-        .ok();
-    let Some(root_id) = root_id else {
-        return Err(AppError::Config(format!("no such root: {old_root_path}")));
+    // Find the root id AND fetch the canonical stored root_path from the
+    // same row. Using the canonical value (not the caller's argument) as
+    // the prefix defends against subtle mismatches (trailing slash, case)
+    // that would otherwise produce silent zero-row updates.
+    let (root_id, canonical_root_path): (i64, String) = match tx.query_row(
+        "SELECT id, root_path FROM roots WHERE root_path = ?1",
+        params![old_root_path],
+        |r| Ok((r.get(0)?, r.get(1)?)),
+    ) {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            return Err(AppError::InvalidPath(format!(
+                "no such root: {old_root_path}"
+            )));
+        }
+        Err(e) => return Err(e.into()),
     };
 
     let roots_updated = tx.execute(
@@ -3854,13 +3860,29 @@ pub fn remap_root(
         params![new_root_path, root_id],
     )?;
 
-    // Rewrite only the prefix of abs_path to avoid clobbering substrings that
-    // match elsewhere in the string.
+    // Count files for this root so we can detect silent prefix mismatches
+    // (e.g. drifted abs_path data where the stored prefix doesn't match
+    // the root's current root_path).
+    let expected_files: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM files WHERE root_id = ?1",
+        params![root_id],
+        |r| r.get(0),
+    )?;
+
+    // Rewrite only the prefix of abs_path to avoid clobbering substrings
+    // that match elsewhere in the string. Use the canonical stored
+    // root_path as the prefix.
     let files_updated = tx.execute(
         "UPDATE files SET abs_path = ?1 || substr(abs_path, length(?2) + 1)
          WHERE root_id = ?3 AND substr(abs_path, 1, length(?2)) = ?2",
-        params![new_root_path, old_root_path, root_id],
+        params![new_root_path, canonical_root_path, root_id],
     )?;
+
+    if files_updated as i64 != expected_files {
+        return Err(AppError::InvalidPath(format!(
+            "remap rewrote {files_updated} of {expected_files} file paths; abs_path prefix mismatch — aborting"
+        )));
+    }
 
     let scan_jobs_updated = tx.execute(
         "UPDATE scan_jobs SET root_path = ?1 WHERE root_id = ?2",
@@ -7005,5 +7027,166 @@ mod tests {
 
         let err = remap_root(&db_path, "D:\\A", "D:\\B");
         assert!(err.is_err(), "remap onto another existing root must fail");
+    }
+
+    #[test]
+    fn remap_root_prefix_only_defense() {
+        // Two files under D:\Photos — one with the root prefix in the
+        // middle of the filename. Only the leading prefix must be rewritten.
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+
+        let root_id = upsert_root(&db_path, "D:\\Photos").unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, 'fp1', 0)",
+            rusqlite::params![root_id, "a/b.jpg", "b.jpg", "D:\\Photos\\a\\b.jpg"],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, 'fp2', 0)",
+            rusqlite::params![
+                root_id,
+                "notes_D_Photos_backup.txt",
+                "notes_D_Photos_backup.txt",
+                "D:\\Photos\\notes_D_Photos_backup.txt",
+            ],
+        ).unwrap();
+        drop(conn);
+
+        let changed = remap_root(&db_path, "D:\\Photos", "E:\\Photos").unwrap();
+        assert_eq!(changed.roots_updated, 1);
+        assert_eq!(changed.files_updated, 2);
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let abs_b: String = conn
+            .query_row(
+                "SELECT abs_path FROM files WHERE rel_path = 'a/b.jpg'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(abs_b, "E:\\Photos\\a\\b.jpg");
+
+        // Only the leading prefix must be rewritten — the substring
+        // "D_Photos" embedded in the filename must NOT be touched.
+        let abs_notes: String = conn
+            .query_row(
+                "SELECT abs_path FROM files WHERE rel_path = 'notes_D_Photos_backup.txt'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(abs_notes, "E:\\Photos\\notes_D_Photos_backup.txt");
+    }
+
+    #[test]
+    fn remap_root_updates_scan_jobs_counter() {
+        // Historical completed scan_jobs rows must also be rewritten so
+        // path-keyed lookups continue to work after the move.
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+
+        let root_id = upsert_root(&db_path, "D:\\X").unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO scan_jobs (
+                root_id, root_path, status, scan_marker,
+                total_files, processed_files, added, modified, moved, unchanged, deleted,
+                started_at, updated_at
+            ) VALUES (?1, ?2, 'completed', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)",
+            rusqlite::params![root_id, "D:\\X"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let changed = remap_root(&db_path, "D:\\X", "E:\\X").unwrap();
+        assert_eq!(changed.scan_jobs_updated, 1);
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let stored: String = conn
+            .query_row(
+                "SELECT root_path FROM scan_jobs WHERE root_id = ?1",
+                rusqlite::params![root_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "E:\\X");
+    }
+
+    #[test]
+    fn remap_root_noop_when_old_equals_new() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+        let root_id = upsert_root(&db_path, "D:\\X").unwrap();
+
+        let changed = remap_root(&db_path, "D:\\X", "D:\\X").unwrap();
+        assert_eq!(changed.roots_updated, 0);
+        assert_eq!(changed.files_updated, 0);
+        assert_eq!(changed.scan_jobs_updated, 0);
+
+        // Row unchanged.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let stored: String = conn
+            .query_row(
+                "SELECT root_path FROM roots WHERE id = ?1",
+                rusqlite::params![root_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "D:\\X");
+    }
+
+    #[test]
+    fn remap_root_rolls_back_on_prefix_mismatch() {
+        // Simulate data drift: a file whose abs_path does NOT start with
+        // the root's root_path. The UPDATE will rewrite 0 rows while
+        // COUNT(*) returns 1, so the remap must error AND rollback.
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+
+        let root_id = upsert_root(&db_path, "D:\\X").unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, 'fp', 0)",
+            rusqlite::params![root_id, "foo.jpg", "foo.jpg", "C:\\somewhere\\foo.jpg"],
+        ).unwrap();
+        drop(conn);
+
+        let err = remap_root(&db_path, "D:\\X", "E:\\X");
+        assert!(
+            err.is_err(),
+            "prefix mismatch must fail so the caller knows to investigate"
+        );
+
+        // Rollback: root_path untouched, file abs_path untouched.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let root_path: String = conn
+            .query_row(
+                "SELECT root_path FROM roots WHERE id = ?1",
+                rusqlite::params![root_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(root_path, "D:\\X");
+
+        let abs: String = conn
+            .query_row(
+                "SELECT abs_path FROM files WHERE root_id = ?1",
+                rusqlite::params![root_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(abs, "C:\\somewhere\\foo.jpg");
     }
 }

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -10,7 +10,7 @@ use crate::models::{
     Album, DbStats, DuplicateFile, DuplicateGroup, DuplicatesResponse, ExistingFile, FileMetadata,
     FileProperties, FileRecordUpsert, HealthCheckOutcome, ParsedQuery, PdfPassword,
     ProtectedPdfInfo, PurgeResult, RootInfo, ScanJobState, ScanJobStatus, SearchItem,
-    SearchRequest, SearchResponse, SmartFolder, SortField, SortOrder, SubdirEntry,
+    SearchRequest, SearchResponse, SmartFolder, SortField, SortOrder, SubdirEntry, TagRule,
 };
 use crate::query_parser::parse_query;
 
@@ -2359,9 +2359,19 @@ pub fn create_album(db_path: &Path, name: &str) -> AppResult<Album> {
     Ok(Album {
         id,
         name: name.to_string(),
+        tag: String::new(),
         created_at: now,
         file_count: 0,
     })
+}
+
+pub fn update_album_tag(db_path: &Path, album_id: i64, tag: &str) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "UPDATE albums SET tag = ?1 WHERE id = ?2",
+        params![tag, album_id],
+    )?;
+    Ok(())
 }
 
 pub fn delete_album(db_path: &Path, album_id: i64) -> AppResult<()> {
@@ -2373,7 +2383,7 @@ pub fn delete_album(db_path: &Path, album_id: i64) -> AppResult<()> {
 pub fn list_albums(db_path: &Path) -> AppResult<Vec<Album>> {
     let conn = open_conn(db_path)?;
     let mut stmt = conn.prepare(
-        "SELECT a.id, a.name, a.created_at,
+        "SELECT a.id, a.name, a.tag, a.created_at,
                 (SELECT COUNT(*) FROM album_files af
                  JOIN files f ON f.id = af.file_id
                  WHERE af.album_id = a.id AND f.deleted_at IS NULL) AS file_count
@@ -2383,8 +2393,9 @@ pub fn list_albums(db_path: &Path) -> AppResult<Vec<Album>> {
         Ok(Album {
             id: row.get(0)?,
             name: row.get(1)?,
-            created_at: row.get(2)?,
-            file_count: row.get::<_, i64>(3)? as u64,
+            tag: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+            created_at: row.get(3)?,
+            file_count: row.get::<_, i64>(4)? as u64,
         })
     })?;
     let mut albums = Vec::new();
@@ -2396,6 +2407,16 @@ pub fn list_albums(db_path: &Path) -> AppResult<Vec<Album>> {
 
 pub fn add_files_to_album(db_path: &Path, album_id: i64, file_ids: &[i64]) -> AppResult<u64> {
     let conn = open_conn(db_path)?;
+    // Fetch album tag for inheritance
+    let album_tag: String = conn
+        .query_row(
+            "SELECT COALESCE(tag, '') FROM albums WHERE id = ?1",
+            params![album_id],
+            |r| r.get(0),
+        )
+        .unwrap_or_default();
+    let tag_trimmed = album_tag.trim().to_string();
+
     let now = now_epoch_secs();
     let mut count = 0u64;
     for fid in file_ids {
@@ -2404,6 +2425,20 @@ pub fn add_files_to_album(db_path: &Path, album_id: i64, file_ids: &[i64]) -> Ap
             params![album_id, fid, now],
         )?;
         count += inserted as u64;
+
+        // Album tag inheritance: append tag to canonical_mentions if not already present
+        if !tag_trimmed.is_empty() {
+            conn.execute(
+                "UPDATE files
+                 SET canonical_mentions = CASE
+                   WHEN canonical_mentions = '' THEN ?1
+                   WHEN instr(',' || canonical_mentions || ',', ',' || ?1 || ',') > 0 THEN canonical_mentions
+                   ELSE canonical_mentions || ',' || ?1
+                 END
+                 WHERE id = ?2",
+                params![tag_trimmed, fid],
+            )?;
+        }
     }
     Ok(count)
 }
@@ -2477,6 +2512,86 @@ pub fn reorder_albums(db_path: &Path, ids: &[i64]) -> AppResult<()> {
 
 pub fn reorder_smart_folders(db_path: &Path, ids: &[i64]) -> AppResult<()> {
     reorder_items(&open_conn(db_path)?, "smart_folders", ids)
+}
+
+// ── Face smart albums ───────────────────────────────────────────────
+
+/// Creates a smart folder that surfaces all photos containing the named person.
+pub fn create_face_smart_album(db_path: &Path, person_name: &str) -> AppResult<SmartFolder> {
+    let query = format!("person:{person_name}");
+    create_smart_folder(db_path, &format!("📷 {person_name}"), &query)
+}
+
+// ── Tag Rules ───────────────────────────────────────────────────────
+
+pub fn list_tag_rules(db_path: &Path) -> AppResult<Vec<TagRule>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt =
+        conn.prepare("SELECT id, pattern, tag, enabled FROM tag_rules ORDER BY id")?;
+    let rows = stmt.query_map([], |row| {
+        Ok(TagRule {
+            id: row.get(0)?,
+            pattern: row.get(1)?,
+            tag: row.get(2)?,
+            enabled: row.get::<_, i64>(3)? != 0,
+        })
+    })?;
+    let mut rules = Vec::new();
+    for row in rows {
+        rules.push(row?);
+    }
+    Ok(rules)
+}
+
+pub fn create_tag_rule(db_path: &Path, pattern: &str, tag: &str) -> AppResult<TagRule> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "INSERT INTO tag_rules (pattern, tag, enabled) VALUES (?1, ?2, 1)",
+        params![pattern, tag],
+    )?;
+    let id = conn.last_insert_rowid();
+    Ok(TagRule {
+        id,
+        pattern: pattern.to_string(),
+        tag: tag.to_string(),
+        enabled: true,
+    })
+}
+
+pub fn delete_tag_rule(db_path: &Path, rule_id: i64) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute("DELETE FROM tag_rules WHERE id = ?1", params![rule_id])?;
+    Ok(())
+}
+
+pub fn set_tag_rule_enabled(db_path: &Path, rule_id: i64, enabled: bool) -> AppResult<()> {
+    let conn = open_conn(db_path)?;
+    conn.execute(
+        "UPDATE tag_rules SET enabled = ?1 WHERE id = ?2",
+        params![enabled as i64, rule_id],
+    )?;
+    Ok(())
+}
+
+/// Returns only enabled tag rules — used at scan time.
+pub fn get_enabled_tag_rules(db_path: &Path) -> AppResult<Vec<TagRule>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, pattern, tag, enabled FROM tag_rules WHERE enabled = 1 ORDER BY id",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(TagRule {
+            id: row.get(0)?,
+            pattern: row.get(1)?,
+            tag: row.get(2)?,
+            enabled: true,
+        })
+    })?;
+    let mut rules = Vec::new();
+    for row in rows {
+        rules.push(row?);
+    }
+    Ok(rules)
 }
 
 // ── PDF Passwords ───────────────────────────────────────────────────
@@ -7515,5 +7630,96 @@ mod tests {
         let res = search_images(&db_path, &req).expect("search color");
         assert_eq!(res.total, 1);
         assert_eq!(res.items[0].rel_path, "red.jpg");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tag rules tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_tag_rules_crud() {
+        let (_dir, db_path) = test_db_path();
+        init_database(&db_path).expect("init");
+
+        // Empty by default
+        let rules = list_tag_rules(&db_path).expect("list empty");
+        assert!(rules.is_empty());
+
+        // Create a rule
+        let rule = create_tag_rule(&db_path, r"^Screenshots/", "screenshot").expect("create");
+        assert_eq!(rule.pattern, r"^Screenshots/");
+        assert_eq!(rule.tag, "screenshot");
+        assert!(rule.enabled);
+
+        // List returns the rule
+        let rules = list_tag_rules(&db_path).expect("list one");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].id, rule.id);
+
+        // Toggle disabled
+        set_tag_rule_enabled(&db_path, rule.id, false).expect("disable");
+        let enabled_only = get_enabled_tag_rules(&db_path).expect("enabled only");
+        assert!(enabled_only.is_empty(), "disabled rule should not appear in enabled list");
+
+        // Delete
+        delete_tag_rule(&db_path, rule.id).expect("delete");
+        let rules = list_tag_rules(&db_path).expect("after delete");
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn test_album_tag_inheritance() {
+        let (_dir, db_path) = test_db_path();
+        init_database(&db_path).expect("init");
+        let root_id = upsert_root(&db_path, "/tmp/demo").expect("root");
+
+        let rec = sample_record(root_id, "photo.jpg", "fp-photo");
+        let file_id = upsert_file_record(&db_path, &rec).expect("upsert");
+
+        // Album with a tag
+        let album = create_album(&db_path, "Vacation").expect("create album");
+        update_album_tag(&db_path, album.id, "vacation").expect("set tag");
+
+        add_files_to_album(&db_path, album.id, &[file_id]).expect("add to album");
+
+        // canonical_mentions should now contain "vacation"
+        let conn = open_conn(&db_path).unwrap();
+        let mentions: String = conn
+            .query_row(
+                "SELECT canonical_mentions FROM files WHERE id = ?1",
+                params![file_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            mentions.contains("vacation"),
+            "canonical_mentions should include 'vacation', got: {mentions}"
+        );
+
+        // Adding twice should not duplicate the tag
+        add_files_to_album(&db_path, album.id, &[file_id]).expect("add again");
+        let mentions2: String = conn
+            .query_row(
+                "SELECT canonical_mentions FROM files WHERE id = ?1",
+                params![file_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let count = mentions2.split(',').filter(|s| *s == "vacation").count();
+        assert_eq!(count, 1, "tag should not be duplicated: {mentions2}");
+    }
+
+    #[test]
+    fn test_face_smart_album_creates_smart_folder() {
+        let (_dir, db_path) = test_db_path();
+        init_database(&db_path).expect("init");
+
+        let sf = create_face_smart_album(&db_path, "Alice").expect("create");
+        assert!(sf.name.contains("Alice"));
+        assert_eq!(sf.query, "person:Alice");
+
+        let folders = list_smart_folders(&db_path).expect("list");
+        assert_eq!(folders.len(), 1);
+        assert_eq!(folders[0].id, sf.id);
     }
 }

--- a/sherlock/desktop/src-tauri/src/db.rs
+++ b/sherlock/desktop/src-tauri/src/db.rs
@@ -23,7 +23,7 @@ const MAX_LIMIT: u32 = 200;
 ///
 /// If the filesystem is read-only (e.g. sandbox, mounted RO), falls back to
 /// opening the database in read-only mode so queries still work.
-fn open_conn(db_path: &Path) -> AppResult<Connection> {
+pub(crate) fn open_conn(db_path: &Path) -> AppResult<Connection> {
     match try_open_rw(db_path) {
         Ok(conn) => Ok(conn),
         Err(ref e) if is_readonly_error(e) => {

--- a/sherlock/desktop/src-tauri/src/exif.rs
+++ b/sherlock/desktop/src-tauri/src/exif.rs
@@ -3,6 +3,95 @@ use std::sync::OnceLock;
 
 use reverse_geocoder::ReverseGeocoder;
 
+/// Lightweight EXIF data extracted during scan — persisted to DB columns added in Migration 13.
+#[derive(Debug, Clone, Default)]
+pub struct ExifScanData {
+    pub camera_model: String,
+    pub lens_model: String,
+    pub iso: Option<i64>,
+    pub shutter_speed: Option<f64>,
+    pub aperture: Option<f64>,
+    pub time_of_day: String,
+}
+
+/// Classify an hour (0–23) to a named time-of-day bucket.
+pub fn classify_time_of_day(hour: u32) -> String {
+    match hour {
+        0..=4 => "night",
+        5..=7 => "dawn",
+        8..=11 => "morning",
+        12..=13 => "noon",
+        14..=17 => "afternoon",
+        18..=20 => "evening",
+        _ => "night",
+    }
+    .to_string()
+}
+
+/// Extract camera/lens/ISO/shutter/aperture/time_of_day from file EXIF.
+/// Returns `ExifScanData::default()` on any error.
+pub fn extract_scan_exif(path: &Path) -> ExifScanData {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return ExifScanData::default(),
+    };
+    let mut buf = std::io::BufReader::new(file);
+    let exif = match exif::Reader::new().read_from_container(&mut buf) {
+        Ok(e) => e,
+        Err(_) => return ExifScanData::default(),
+    };
+
+    let get_str = |tag: exif::Tag| -> String {
+        exif.get_field(tag, exif::In::PRIMARY)
+            .map(|f| {
+                let s = f.display_value().to_string();
+                s.trim().trim_matches('"').to_string()
+            })
+            .filter(|s| !s.is_empty())
+            .unwrap_or_default()
+    };
+
+    let camera_model = get_str(exif::Tag::Model);
+    let lens_model = get_str(exif::Tag::LensModel);
+
+    let iso = exif
+        .get_field(exif::Tag::PhotographicSensitivity, exif::In::PRIMARY)
+        .and_then(|f| match &f.value {
+            exif::Value::Short(v) => v.first().map(|x| *x as i64),
+            exif::Value::Long(v) => v.first().map(|x| *x as i64),
+            _ => f.display_value().to_string().trim().parse::<i64>().ok(),
+        });
+
+    let shutter_speed = exif
+        .get_field(exif::Tag::ExposureTime, exif::In::PRIMARY)
+        .and_then(|f| match &f.value {
+            exif::Value::Rational(v) if !v.is_empty() => Some(v[0].to_f64()),
+            _ => None,
+        });
+
+    let aperture = exif
+        .get_field(exif::Tag::FNumber, exif::In::PRIMARY)
+        .and_then(|f| match &f.value {
+            exif::Value::Rational(v) if !v.is_empty() => Some(v[0].to_f64()),
+            _ => None,
+        });
+
+    let time_of_day = exif
+        .get_field(exif::Tag::DateTimeOriginal, exif::In::PRIMARY)
+        .and_then(|f| {
+            // EXIF datetime format: "2023:01:15 14:32:45"
+            let s = f.display_value().to_string();
+            s.split_whitespace()
+                .nth(1)
+                .and_then(|t| t.split(':').next())
+                .and_then(|h| h.parse::<u32>().ok())
+                .map(classify_time_of_day)
+        })
+        .unwrap_or_default();
+
+    ExifScanData { camera_model, lens_model, iso, shutter_speed, aperture, time_of_day }
+}
+
 static GEOCODER: OnceLock<ReverseGeocoder> = OnceLock::new();
 
 fn geocoder() -> &'static ReverseGeocoder {
@@ -316,5 +405,33 @@ mod tests {
         let result = apply_orientation(img, 2);
         assert_eq!(result.width(), 4);
         assert_eq!(result.height(), 2);
+    }
+
+    #[test]
+    fn classify_time_of_day_buckets() {
+        assert_eq!(classify_time_of_day(2), "night");
+        assert_eq!(classify_time_of_day(6), "dawn");
+        assert_eq!(classify_time_of_day(10), "morning");
+        assert_eq!(classify_time_of_day(12), "noon");
+        assert_eq!(classify_time_of_day(15), "afternoon");
+        assert_eq!(classify_time_of_day(19), "evening");
+        assert_eq!(classify_time_of_day(23), "night");
+    }
+
+    #[test]
+    fn extract_scan_exif_nonexistent_returns_default() {
+        let data = extract_scan_exif(Path::new("/nonexistent/file.jpg"));
+        assert!(data.camera_model.is_empty());
+        assert!(data.iso.is_none());
+        assert!(data.time_of_day.is_empty());
+    }
+
+    #[test]
+    fn extract_scan_exif_non_image_returns_default() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), b"not an image").expect("write");
+        let data = extract_scan_exif(tmp.path());
+        assert!(data.camera_model.is_empty());
+        assert!(data.iso.is_none());
     }
 }

--- a/sherlock/desktop/src-tauri/src/filters.rs
+++ b/sherlock/desktop/src-tauri/src/filters.rs
@@ -1,0 +1,110 @@
+//! Aggregation queries that feed the search-filter UI — camera/lens pickers.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterOption {
+    pub value: String,
+    pub count: i64,
+}
+
+pub fn list_cameras(db_path: &Path) -> AppResult<Vec<FilterOption>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT camera_model, COUNT(*) AS c FROM files
+         WHERE deleted_at IS NULL AND camera_model != ''
+         GROUP BY camera_model ORDER BY c DESC, camera_model ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |r| Ok(FilterOption { value: r.get(0)?, count: r.get(1)? }))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+pub fn list_lenses(db_path: &Path) -> AppResult<Vec<FilterOption>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT lens_model, COUNT(*) AS c FROM files
+         WHERE deleted_at IS NULL AND lens_model != ''
+         GROUP BY lens_model ORDER BY c DESC, lens_model ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |r| Ok(FilterOption { value: r.get(0)?, count: r.get(1)? }))?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+#[tauri::command]
+pub async fn list_cameras_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<FilterOption>, String> {
+    list_cameras(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn list_lenses_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<FilterOption>, String> {
+    list_lenses(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn seed(conn: &Connection, root_id: i64, filename: &str, camera: &str, lens: &str) {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes,
+                                fingerprint, updated_at, camera_model, lens_model)
+             VALUES (?1, ?2, ?3, ?4, 0, 0, ?5, 0, ?6, ?7)",
+            rusqlite::params![
+                root_id,
+                filename,
+                filename,
+                format!("/tmp/{filename}"),
+                format!("fp-{filename}"),
+                camera,
+                lens
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn list_cameras_groups_and_counts_descending() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        seed(&conn, root, "a.jpg", "Canon EOS R5", "RF 24-70mm");
+        seed(&conn, root, "b.jpg", "Canon EOS R5", "RF 24-70mm");
+        seed(&conn, root, "c.jpg", "iPhone 14 Pro", "");
+        drop(conn);
+
+        let out = list_cameras(&db).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].value, "Canon EOS R5");
+        assert_eq!(out[0].count, 2);
+        assert_eq!(out[1].value, "iPhone 14 Pro");
+    }
+
+    #[test]
+    fn list_lenses_skips_empty() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        seed(&conn, root, "a.jpg", "", "50mm f/1.8");
+        seed(&conn, root, "b.jpg", "", "");
+        drop(conn);
+
+        let out = list_lenses(&db).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].value, "50mm f/1.8");
+    }
+}

--- a/sherlock/desktop/src-tauri/src/find_similar.rs
+++ b/sherlock/desktop/src-tauri/src/find_similar.rs
@@ -1,17 +1,9 @@
 //! Ranked "find similar" query using dHash + description similarity.
+use crate::db::open_conn;
 use crate::error::{AppError, AppResult};
 use crate::similarity::{combined_similarity, hamming_distance};
-use rusqlite::{params, Connection};
+use rusqlite::params;
 use std::path::Path;
-
-/// Local connection helper mirroring `db::open_conn` (which is private).
-/// Sets busy_timeout and foreign_keys on every connection.
-fn open_conn(db_path: &Path) -> AppResult<Connection> {
-    let conn = Connection::open(db_path)?;
-    conn.pragma_update(None, "busy_timeout", 5000)?;
-    conn.pragma_update(None, "foreign_keys", "ON")?;
-    Ok(conn)
-}
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/sherlock/desktop/src-tauri/src/find_similar.rs
+++ b/sherlock/desktop/src-tauri/src/find_similar.rs
@@ -1,0 +1,274 @@
+//! Ranked "find similar" query using dHash + description similarity.
+use crate::error::{AppError, AppResult};
+use crate::similarity::{combined_similarity, hamming_distance};
+use rusqlite::{params, Connection};
+use std::path::Path;
+
+/// Local connection helper mirroring `db::open_conn` (which is private).
+/// Sets busy_timeout and foreign_keys on every connection.
+fn open_conn(db_path: &Path) -> AppResult<Connection> {
+    let conn = Connection::open(db_path)?;
+    conn.pragma_update(None, "busy_timeout", 5000)?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    Ok(conn)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimilarResult {
+    pub file_id: i64,
+    pub root_id: i64,
+    pub rel_path: String,
+    pub abs_path: String,
+    pub filename: String,
+    pub media_type: String,
+    pub description: String,
+    pub thumb_path: Option<String>,
+    pub score: f32,
+}
+
+/// Early-exit pruning: if visual alone can't exceed `min_score`, skip the row.
+/// combined = 0.85 * visual + 0.15 * textual; textual ≤ 1.0, so:
+///   visual ≥ (min_score - 0.15) / 0.85
+///   hamming ≤ (1 - visual) * 64
+fn max_hamming_for(min_score: f32) -> u32 {
+    let visual_min = ((min_score - 0.15) / 0.85).max(0.0);
+    ((1.0 - visual_min) * 64.0).floor() as u32
+}
+
+/// Rank all other files by `combined_similarity` to the source file.
+/// Returns the top `limit` with `score ≥ min_score`, descending by score.
+pub fn find_similar(
+    db_path: &Path,
+    source_file_id: i64,
+    limit: usize,
+    min_score: f32,
+) -> AppResult<Vec<SimilarResult>> {
+    let conn = open_conn(db_path)?;
+
+    // Fetch the source row.
+    let (src_dhash, src_desc, src_media_type): (Option<i64>, String, String) = conn
+        .query_row(
+            "SELECT dhash, description, media_type FROM files
+             WHERE id = ?1 AND deleted_at IS NULL",
+            params![source_file_id],
+            |row| {
+                Ok((
+                    row.get::<_, Option<i64>>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AppError::InvalidPath(format!("no such file: {source_file_id}"))
+            }
+            other => other.into(),
+        })?;
+
+    let src_dhash = match src_dhash {
+        Some(v) => v as u64,
+        None => {
+            // No dHash on source — fall back is out of scope; return empty.
+            return Ok(Vec::new());
+        }
+    };
+
+    let max_h = max_hamming_for(min_score);
+
+    let mut stmt = conn.prepare(
+        "SELECT f.id, f.root_id, f.rel_path, f.filename, f.abs_path,
+                f.media_type, f.description, f.thumb_path, f.dhash
+         FROM files f
+         WHERE f.id != ?1
+           AND f.deleted_at IS NULL
+           AND f.dhash IS NOT NULL
+           AND f.media_type = ?2",
+    )?;
+
+    let mut scored: Vec<SimilarResult> = Vec::new();
+    type Row = (
+        i64,
+        i64,
+        String,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        u64,
+    );
+    let rows = stmt.query_map(params![source_file_id, src_media_type], |row| -> rusqlite::Result<Row> {
+        let dhash: i64 = row.get(8)?;
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, String>(6)?,
+            row.get::<_, Option<String>>(7)?,
+            dhash as u64,
+        ))
+    })?;
+
+    for row in rows {
+        let (file_id, root_id, rel_path, filename, abs_path, media_type, description, thumb_path, cand_dhash) = row?;
+        if hamming_distance(src_dhash, cand_dhash) > max_h {
+            continue;
+        }
+        let score = combined_similarity(src_dhash, cand_dhash, &src_desc, &description);
+        if score < min_score {
+            continue;
+        }
+        scored.push(SimilarResult {
+            file_id,
+            root_id,
+            rel_path,
+            abs_path,
+            filename,
+            media_type,
+            description,
+            thumb_path,
+            score,
+        });
+    }
+
+    scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+    Ok(scored)
+}
+
+#[tauri::command]
+pub async fn find_similar_cmd(
+    state: tauri::State<'_, crate::AppState>,
+    file_id: i64,
+    limit: usize,
+    min_score: f32,
+) -> Result<Vec<SimilarResult>, String> {
+    find_similar(&state.paths.db_file, file_id, limit, min_score).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn seed_file(
+        conn: &Connection,
+        root_id: i64,
+        filename: &str,
+        rel_path: &str,
+        media_type: &str,
+        description: &str,
+        dhash: Option<i64>,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO files (root_id, rel_path, filename, abs_path, media_type, description,
+                                mtime_ns, size_bytes, fingerprint, updated_at, dhash)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, 0, ?7, 0, ?8)",
+            rusqlite::params![
+                root_id,
+                rel_path,
+                filename,
+                format!("D:\\Photos\\{rel_path}"),
+                media_type,
+                description,
+                format!("fp-{filename}"),
+                dhash,
+            ],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn setup() -> (tempfile::TempDir, std::path::PathBuf, i64) {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.sqlite");
+        init_database(&db_path).unwrap();
+        let root_id = upsert_root(&db_path, "D:\\Photos").unwrap();
+        (dir, db_path, root_id)
+    }
+
+    #[test]
+    fn find_similar_returns_high_scoring_candidates() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "a.jpg", "a.jpg", "photo", "sunset over beach", Some(0));
+        let close = seed_file(&conn, root_id, "b.jpg", "b.jpg", "photo", "sunset over beach", Some(0b11));
+        let far = seed_file(&conn, root_id, "c.jpg", "c.jpg", "photo", "car in parking lot",
+            Some(i64::from_le_bytes(0xFFFFFFFFFFFFFFFFu64.to_le_bytes())));
+        let doc = seed_file(&conn, root_id, "d.jpg", "d.jpg", "document", "sunset over beach", Some(0));
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        let ids: Vec<i64> = out.iter().map(|r| r.file_id).collect();
+        assert!(ids.contains(&close), "expected close match included, got {ids:?}");
+        assert!(!ids.contains(&far), "expected far match excluded by min_score 0.5, got {ids:?}");
+        assert!(!ids.contains(&src));
+        assert!(!ids.contains(&doc), "document media_type must be filtered out");
+
+        let scores: Vec<f32> = out.iter().map(|r| r.score).collect();
+        let mut sorted = scores.clone();
+        sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        assert_eq!(scores, sorted);
+    }
+
+    #[test]
+    fn find_similar_respects_limit() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "cat on couch", Some(0));
+        for i in 0..5 {
+            seed_file(
+                &conn,
+                root_id,
+                &format!("n{i}.jpg"),
+                &format!("n{i}.jpg"),
+                "photo",
+                "cat on couch",
+                Some(i as i64),
+            );
+        }
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 2, 0.5).unwrap();
+        assert_eq!(out.len(), 2, "limit must cap results at 2");
+    }
+
+    #[test]
+    fn find_similar_returns_empty_when_source_has_no_dhash() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "x", None);
+        seed_file(&conn, root_id, "c.jpg", "c.jpg", "photo", "x", Some(0));
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        assert!(out.is_empty(), "source without dhash should yield empty results");
+    }
+
+    #[test]
+    fn find_similar_errors_on_unknown_source() {
+        let (_dir, db_path, _root_id) = setup();
+        let err = find_similar(&db_path, 9999, 10, 0.5);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn find_similar_excludes_deleted_candidates() {
+        let (_dir, db_path, root_id) = setup();
+        let conn = Connection::open(&db_path).unwrap();
+        let src = seed_file(&conn, root_id, "src.jpg", "src.jpg", "photo", "sunset", Some(0));
+        let gone = seed_file(&conn, root_id, "gone.jpg", "gone.jpg", "photo", "sunset", Some(0));
+        conn.execute("UPDATE files SET deleted_at = 1 WHERE id = ?1", rusqlite::params![gone]).unwrap();
+        drop(conn);
+
+        let out = find_similar(&db_path, src, 10, 0.5).unwrap();
+        assert!(out.iter().all(|r| r.file_id != gone));
+    }
+}

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod llm;
 mod models;
 mod pdf;
 mod platform;
+mod portability;
 mod query_parser;
 mod runtime;
 mod scan;
@@ -33,8 +34,8 @@ use tauri::Manager;
 use tauri::State;
 
 #[derive(Clone)]
-struct AppState {
-    paths: AppPaths,
+pub(crate) struct AppState {
+    pub(crate) paths: AppPaths,
     read_only: bool,
     gpu_info: Arc<OnceLock<platform::gpu::GpuInfo>>,
     running_scan_jobs: Arc<Mutex<HashSet<i64>>>,
@@ -1721,6 +1722,7 @@ pub fn run() {
             get_runtime_status,
             cancel_scan,
             remove_root,
+            portability::remap_root_cmd,
             list_roots,
             list_subdirectories,
             load_user_config,

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod db;
 mod error;
 mod exif;
 mod face;
+mod find_similar;
 mod llm;
 mod models;
 mod pdf;
@@ -1765,7 +1766,8 @@ pub fn run() {
             list_faces_for_person,
             unassign_face_from_person,
             reassign_faces_to_person,
-            set_representative_face
+            set_representative_face,
+            find_similar::find_similar_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod runtime;
 mod scan;
 mod similarity;
 mod thumbnail;
+mod timeline;
 mod video;
 mod video_server;
 
@@ -1809,7 +1810,8 @@ pub fn run() {
             find_similar::find_similar_cmd,
             filters::list_cameras_cmd,
             filters::list_lenses_cmd,
-            autocomplete::suggest_cmd
+            autocomplete::suggest_cmd,
+            timeline::list_timeline_buckets_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod autocomplete;
 mod classify;
+mod clustering;
 mod config;
 mod db;
 mod error;
@@ -1656,6 +1657,7 @@ pub fn run() {
                 // Full read-write mode
                 db::recover_incomplete_scan_jobs(&paths.db_file).ok();
                 backfill_exif_extras(&paths.db_file).ok();
+                clustering::backfill_shot_kind(&paths.db_file).ok();
 
                 match db::startup_health_check(&paths.db_file, &paths.db_dir) {
                     Ok(HealthCheckOutcome::RestoredFromBackup) => {
@@ -1811,7 +1813,17 @@ pub fn run() {
             filters::list_cameras_cmd,
             filters::list_lenses_cmd,
             autocomplete::suggest_cmd,
-            timeline::list_timeline_buckets_cmd
+            timeline::list_timeline_buckets_cmd,
+            clustering::recompute_events_cmd,
+            clustering::list_events_cmd,
+            clustering::detect_trips_cmd,
+            clustering::list_trips_cmd,
+            clustering::find_bursts_cmd,
+            clustering::generate_year_review_cmd,
+            clustering::set_dedup_policy_cmd,
+            clustering::get_dedup_policy_cmd,
+            clustering::apply_dedup_policy_cmd,
+            clustering::backfill_shot_kind_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -1725,6 +1725,8 @@ pub fn run() {
             portability::remap_root_cmd,
             portability::export_catalog_cmd,
             portability::import_catalog_cmd,
+            portability::get_portable_root_cmd,
+            portability::set_portable_root_cmd,
             list_roots,
             list_subdirectories,
             load_user_config,

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,11 @@
+mod autocomplete;
 mod classify;
 mod config;
 mod db;
 mod error;
 mod exif;
 mod face;
+mod filters;
 mod find_similar;
 mod llm;
 mod models;
@@ -1612,6 +1614,36 @@ fn spawn_scan_worker_if_needed(
     });
 }
 
+/// Re-extract EXIF for up to 200 files per startup that are missing camera/lens data.
+/// Runs silently — errors are ignored to avoid blocking startup.
+fn backfill_exif_extras(db_path: &std::path::Path) -> error::AppResult<()> {
+    let conn = db::open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, abs_path FROM files
+         WHERE deleted_at IS NULL AND camera_model = '' AND lens_model = ''
+         ORDER BY id DESC LIMIT 200",
+    )?;
+    let rows: Vec<(i64, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .filter_map(Result::ok)
+        .collect();
+    for (id, path) in rows {
+        let meta = exif::extract_scan_exif(std::path::Path::new(&path));
+        if !meta.camera_model.is_empty() || meta.iso.is_some() {
+            let _ = conn.execute(
+                "UPDATE files SET camera_model = ?1, lens_model = ?2, iso = ?3,
+                                   shutter_speed = ?4, aperture = ?5, time_of_day = ?6
+                 WHERE id = ?7",
+                rusqlite::params![
+                    meta.camera_model, meta.lens_model, meta.iso,
+                    meta.shutter_speed, meta.aperture, meta.time_of_day, id
+                ],
+            );
+        }
+    }
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let (paths, read_only) = resolve_paths()
@@ -1622,6 +1654,7 @@ pub fn run() {
             if init_ok {
                 // Full read-write mode
                 db::recover_incomplete_scan_jobs(&paths.db_file).ok();
+                backfill_exif_extras(&paths.db_file).ok();
 
                 match db::startup_health_check(&paths.db_file, &paths.db_dir) {
                     Ok(HealthCheckOutcome::RestoredFromBackup) => {
@@ -1773,7 +1806,10 @@ pub fn run() {
             unassign_face_from_person,
             reassign_faces_to_person,
             set_representative_face,
-            find_similar::find_similar_cmd
+            find_similar::find_similar_cmd,
+            filters::list_cameras_cmd,
+            filters::list_lenses_cmd,
+            autocomplete::suggest_cmd
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -33,7 +33,7 @@ use models::{
     Album, DeleteFilesResult, DuplicatesResponse, HealthCheckOutcome, HealthStatus, PdfPassword,
     ProtectedPdfInfo, PurgeResult, RenameFileResult, RetryProtectedPdfsResult, RootInfo,
     RuntimeStatus, ScanJobStatus, SearchRequest, SearchResponse, SetupDownloadStatus, SetupStatus,
-    SmartFolder, SubdirEntry, TagRule, VenvProvisionStatus,
+    SavedSearch, SmartFolder, SubdirEntry, TagRule, VenvProvisionStatus,
 };
 use tauri::Manager;
 use tauri::State;
@@ -689,6 +689,40 @@ fn delete_smart_folder(folder_id: i64, state: State<'_, AppState>) -> Result<(),
 #[tauri::command]
 fn list_smart_folders(state: State<'_, AppState>) -> Result<Vec<SmartFolder>, String> {
     db::list_smart_folders(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+// ── Saved search commands ────────────────────────────────────────────
+
+#[tauri::command]
+fn list_saved_searches(state: State<'_, AppState>) -> Result<Vec<SavedSearch>, String> {
+    db::list_saved_searches(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn create_saved_search(
+    name: String,
+    query: String,
+    state: State<'_, AppState>,
+) -> Result<SavedSearch, String> {
+    require_writable(state.inner())?;
+    db::create_saved_search(&state.paths.db_file, &name, &query).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn delete_saved_search(search_id: i64, state: State<'_, AppState>) -> Result<(), String> {
+    require_writable(state.inner())?;
+    db::delete_saved_search(&state.paths.db_file, search_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn set_saved_search_notify(
+    search_id: i64,
+    notify: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    require_writable(state.inner())?;
+    db::set_saved_search_notify(&state.paths.db_file, search_id, notify)
+        .map_err(|e| e.to_string())
 }
 
 // ── Reorder commands ────────────────────────────────────────────────
@@ -1845,6 +1879,10 @@ pub fn run() {
             create_tag_rule,
             delete_tag_rule,
             set_tag_rule_enabled,
+            list_saved_searches,
+            create_saved_search,
+            delete_saved_search,
+            set_saved_search_notify,
             reorder_roots,
             reorder_albums,
             reorder_smart_folders,

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -1723,6 +1723,7 @@ pub fn run() {
             cancel_scan,
             remove_root,
             portability::remap_root_cmd,
+            portability::export_catalog_cmd,
             list_roots,
             list_subdirectories,
             load_user_config,

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -1724,6 +1724,7 @@ pub fn run() {
             remove_root,
             portability::remap_root_cmd,
             portability::export_catalog_cmd,
+            portability::import_catalog_cmd,
             list_roots,
             list_subdirectories,
             load_user_config,

--- a/sherlock/desktop/src-tauri/src/lib.rs
+++ b/sherlock/desktop/src-tauri/src/lib.rs
@@ -33,7 +33,7 @@ use models::{
     Album, DeleteFilesResult, DuplicatesResponse, HealthCheckOutcome, HealthStatus, PdfPassword,
     ProtectedPdfInfo, PurgeResult, RenameFileResult, RetryProtectedPdfsResult, RootInfo,
     RuntimeStatus, ScanJobStatus, SearchRequest, SearchResponse, SetupDownloadStatus, SetupStatus,
-    SmartFolder, SubdirEntry, VenvProvisionStatus,
+    SmartFolder, SubdirEntry, TagRule, VenvProvisionStatus,
 };
 use tauri::Manager;
 use tauri::State;
@@ -612,6 +612,18 @@ fn remove_files_from_album(
         .map_err(|e| e.to_string())
 }
 
+// ── Album tag inheritance command ───────────────────────────────────
+
+#[tauri::command]
+fn update_album_tag(
+    album_id: i64,
+    tag: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    require_writable(state.inner())?;
+    db::update_album_tag(&state.paths.db_file, album_id, &tag).map_err(|e| e.to_string())
+}
+
 // ── Smart folder commands ───────────────────────────────────────────
 
 #[tauri::command]
@@ -622,6 +634,50 @@ fn create_smart_folder(
 ) -> Result<SmartFolder, String> {
     require_writable(state.inner())?;
     db::create_smart_folder(&state.paths.db_file, &name, &query).map_err(|e| e.to_string())
+}
+
+// ── Face smart album command ─────────────────────────────────────────
+
+#[tauri::command]
+fn create_face_smart_album(
+    person_name: String,
+    state: State<'_, AppState>,
+) -> Result<SmartFolder, String> {
+    require_writable(state.inner())?;
+    db::create_face_smart_album(&state.paths.db_file, &person_name).map_err(|e| e.to_string())
+}
+
+// ── Tag rules commands ───────────────────────────────────────────────
+
+#[tauri::command]
+fn list_tag_rules(state: State<'_, AppState>) -> Result<Vec<TagRule>, String> {
+    db::list_tag_rules(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn create_tag_rule(
+    pattern: String,
+    tag: String,
+    state: State<'_, AppState>,
+) -> Result<TagRule, String> {
+    require_writable(state.inner())?;
+    db::create_tag_rule(&state.paths.db_file, &pattern, &tag).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn delete_tag_rule(rule_id: i64, state: State<'_, AppState>) -> Result<(), String> {
+    require_writable(state.inner())?;
+    db::delete_tag_rule(&state.paths.db_file, rule_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn set_tag_rule_enabled(
+    rule_id: i64,
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    require_writable(state.inner())?;
+    db::set_tag_rule_enabled(&state.paths.db_file, rule_id, enabled).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1780,9 +1836,15 @@ pub fn run() {
             list_albums,
             add_files_to_album,
             remove_files_from_album,
+            update_album_tag,
             create_smart_folder,
             delete_smart_folder,
             list_smart_folders,
+            create_face_smart_album,
+            list_tag_rules,
+            create_tag_rule,
+            delete_tag_rule,
+            set_tag_rule_enabled,
             reorder_roots,
             reorder_albums,
             reorder_smart_folders,

--- a/sherlock/desktop/src-tauri/src/models.rs
+++ b/sherlock/desktop/src-tauri/src/models.rs
@@ -108,6 +108,12 @@ pub struct ParsedQuery {
     pub lens_model: Option<String>,
     #[serde(default)]
     pub time_of_day: Option<String>,
+    /// "selfie" | "group" | "landscape" from shot: token
+    #[serde(default)]
+    pub shot_kind: Option<String>,
+    /// Some(true) = only blurry, Some(false) = exclude blurry, None = no filter
+    #[serde(default)]
+    pub blur: Option<bool>,
 }
 
 impl ParsedQuery {
@@ -127,6 +133,8 @@ impl ParsedQuery {
             camera_model: None,
             lens_model: None,
             time_of_day: None,
+            shot_kind: None,
+            blur: None,
         }
     }
 }
@@ -290,6 +298,7 @@ pub struct FileRecordUpsert {
     pub shutter_speed: Option<f64>,
     pub aperture: Option<f64>,
     pub time_of_day: String,
+    pub blur_score: Option<f64>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/sherlock/desktop/src-tauri/src/models.rs
+++ b/sherlock/desktop/src-tauri/src/models.rs
@@ -114,6 +114,9 @@ pub struct ParsedQuery {
     /// Some(true) = only blurry, Some(false) = exclude blurry, None = no filter
     #[serde(default)]
     pub blur: Option<bool>,
+    /// Dominant-color filter: packed 0x00RRGGBB. None = no filter.
+    #[serde(default)]
+    pub color_hex: Option<u32>,
 }
 
 impl ParsedQuery {
@@ -135,6 +138,7 @@ impl ParsedQuery {
             time_of_day: None,
             shot_kind: None,
             blur: None,
+            color_hex: None,
         }
     }
 }
@@ -299,6 +303,8 @@ pub struct FileRecordUpsert {
     pub aperture: Option<f64>,
     pub time_of_day: String,
     pub blur_score: Option<f64>,
+    pub dominant_color: Option<i64>,
+    pub qr_codes: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/sherlock/desktop/src-tauri/src/models.rs
+++ b/sherlock/desktop/src-tauri/src/models.rs
@@ -102,6 +102,12 @@ pub struct ParsedQuery {
     pub person_id: Option<i64>,
     #[serde(default)]
     pub person_name: Option<String>,
+    #[serde(default)]
+    pub camera_model: Option<String>,
+    #[serde(default)]
+    pub lens_model: Option<String>,
+    #[serde(default)]
+    pub time_of_day: Option<String>,
 }
 
 impl ParsedQuery {
@@ -118,6 +124,9 @@ impl ParsedQuery {
             subdir: None,
             person_id: None,
             person_name: None,
+            camera_model: None,
+            lens_model: None,
+            time_of_day: None,
         }
     }
 }
@@ -275,6 +284,12 @@ pub struct FileRecordUpsert {
     pub video_height: Option<u32>,
     pub video_codec: Option<String>,
     pub audio_codec: Option<String>,
+    pub camera_model: String,
+    pub lens_model: String,
+    pub iso: Option<i64>,
+    pub shutter_speed: Option<f64>,
+    pub aperture: Option<f64>,
+    pub time_of_day: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/sherlock/desktop/src-tauri/src/models.rs
+++ b/sherlock/desktop/src-tauri/src/models.rs
@@ -148,6 +148,7 @@ impl ParsedQuery {
 pub struct Album {
     pub id: i64,
     pub name: String,
+    pub tag: String,
     pub created_at: i64,
     pub file_count: u64,
 }
@@ -159,6 +160,26 @@ pub struct SmartFolder {
     pub name: String,
     pub query: String,
     pub created_at: i64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TagRule {
+    pub id: i64,
+    pub pattern: String,
+    pub tag: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SavedSearch {
+    pub id: i64,
+    pub name: String,
+    pub query: String,
+    pub notify: bool,
+    pub last_match_id: i64,
+    pub last_checked_at: i64,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/sherlock/desktop/src-tauri/src/portability.rs
+++ b/sherlock/desktop/src-tauri/src/portability.rs
@@ -185,6 +185,36 @@ pub async fn import_catalog_cmd(
         .map_err(|e| e.to_string())
 }
 
+/// Read the configured portable root (if any) from user_config.
+#[tauri::command]
+pub async fn get_portable_root_cmd() -> Result<Option<String>, String> {
+    let cfg = crate::config::load_user_config().map_err(|e| e.to_string())?;
+    Ok(cfg.get("portableRoot").and_then(|v| v.as_str()).map(|s| s.to_string()))
+}
+
+/// Persist the portable root to user_config. Pass `None` to clear it.
+/// Changes take effect on the next app launch.
+#[tauri::command]
+pub async fn set_portable_root_cmd(portable_root: Option<String>) -> Result<(), String> {
+    use serde_json::json;
+    let mut cfg = crate::config::load_user_config().map_err(|e| e.to_string())?;
+    let map = cfg.as_object_mut().ok_or("user_config is not a JSON object")?;
+    match portable_root {
+        Some(s) if !s.trim().is_empty() => {
+            // Validate the path exists and is a directory.
+            let p = std::path::Path::new(&s);
+            if !p.is_dir() {
+                return Err(format!("portable root is not a directory: {s}"));
+            }
+            map.insert("portableRoot".to_string(), json!(s));
+        }
+        _ => {
+            map.remove("portableRoot");
+        }
+    }
+    crate::config::save_user_config(&cfg).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod export_tests {
     use super::*;

--- a/sherlock/desktop/src-tauri/src/portability.rs
+++ b/sherlock/desktop/src-tauri/src/portability.rs
@@ -1,0 +1,13 @@
+//! Portability commands: remap, export, import, portable mode toggle.
+use crate::db;
+use crate::AppState;
+
+#[tauri::command]
+pub async fn remap_root_cmd(
+    state: tauri::State<'_, AppState>,
+    old_path: String,
+    new_path: String,
+) -> Result<db::RemapReport, String> {
+    db::remap_root(&state.paths.db_file, &old_path, &new_path)
+        .map_err(|e| e.to_string())
+}

--- a/sherlock/desktop/src-tauri/src/portability.rs
+++ b/sherlock/desktop/src-tauri/src/portability.rs
@@ -1,6 +1,8 @@
 //! Portability commands: remap, export, import, portable mode toggle.
 use crate::db;
+use crate::error::{AppError, AppResult};
 use crate::AppState;
+use std::path::Path;
 
 #[tauri::command]
 pub async fn remap_root_cmd(
@@ -10,4 +12,151 @@ pub async fn remap_root_cmd(
 ) -> Result<db::RemapReport, String> {
     db::remap_root(&state.paths.db_file, &old_path, &new_path)
         .map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportReport {
+    pub zip_path: String,
+    pub entries: usize,
+    pub bytes: u64,
+}
+
+/// Export db + thumbnails + classifications into a single zip.
+/// `base_dir` is the AppPaths base (what `config::resolve_paths().base_dir` returns).
+/// Refuses to overwrite an existing zip at `zip_path`.
+pub fn export_catalog_at(base_dir: &Path, zip_path: &Path) -> AppResult<ExportReport> {
+    use std::io::Write;
+
+    if zip_path.exists() {
+        return Err(AppError::InvalidPath(format!(
+            "refusing to overwrite existing file: {}",
+            zip_path.display()
+        )));
+    }
+
+    if let Some(parent) = zip_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    let file = std::fs::File::create(zip_path)
+        .map_err(|e| AppError::Config(format!("cannot create zip: {e}")))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let opts: zip::write::FileOptions<()> =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let mut entries = 0usize;
+    let mut bytes = 0u64;
+
+    for rel in [
+        Path::new("db"),
+        Path::new("cache/thumbnails"),
+        Path::new("cache/classifications"),
+    ] {
+        let abs = base_dir.join(rel);
+        if !abs.exists() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&abs) {
+            let entry = entry.map_err(|e| AppError::Config(format!("walk {}: {e}", rel.display())))?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let rel_in_zip = entry
+                .path()
+                .strip_prefix(base_dir)
+                .map_err(|e| AppError::Config(format!("strip_prefix: {e}")))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            zip.start_file(&rel_in_zip, opts)
+                .map_err(|e| AppError::Config(format!("zip start: {e}")))?;
+            let data = std::fs::read(entry.path())?;
+            zip.write_all(&data)
+                .map_err(|e| AppError::Config(format!("zip write: {e}")))?;
+            entries += 1;
+            bytes += data.len() as u64;
+        }
+    }
+
+    zip.finish()
+        .map_err(|e| AppError::Config(format!("zip finish: {e}")))?;
+    Ok(ExportReport {
+        zip_path: zip_path.to_string_lossy().into_owned(),
+        entries,
+        bytes,
+    })
+}
+
+#[tauri::command]
+pub async fn export_catalog_cmd(
+    state: tauri::State<'_, AppState>,
+    out_zip: String,
+) -> Result<ExportReport, String> {
+    export_catalog_at(&state.paths.base_dir, std::path::Path::new(&out_zip))
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod export_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn export_catalog_bundles_db_and_caches() {
+        let src = tempdir().unwrap();
+        let out = tempdir().unwrap();
+
+        // Fake AppPaths layout.
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"sqlitebytes").unwrap();
+        fs::create_dir_all(src.path().join("cache/thumbnails/root/a")).unwrap();
+        fs::write(src.path().join("cache/thumbnails/root/a/b.jpg"), b"thumb").unwrap();
+        fs::create_dir_all(src.path().join("cache/classifications/root/a")).unwrap();
+        fs::write(src.path().join("cache/classifications/root/a/b.json"), b"{}").unwrap();
+
+        let zip_path = out.path().join("catalog.zip");
+        let report = export_catalog_at(src.path(), &zip_path).unwrap();
+        assert!(zip_path.exists(), "zip should exist on disk");
+        assert!(report.entries >= 3, "expected >=3 entries, got {}", report.entries);
+
+        // Sanity: the zip opens and contains our files.
+        let f = fs::File::open(&zip_path).unwrap();
+        let mut arch = zip::ZipArchive::new(f).unwrap();
+        let names: Vec<String> = (0..arch.len())
+            .map(|i| arch.by_index(i).unwrap().name().to_string())
+            .collect();
+        assert!(names.iter().any(|n| n.ends_with("index.sqlite")), "missing index.sqlite in {names:?}");
+        assert!(names.iter().any(|n| n.contains("thumbnails/") || n.contains("thumbnails\\")), "missing thumbnails in {names:?}");
+    }
+
+    #[test]
+    fn export_catalog_handles_missing_cache_dirs() {
+        // If cache/thumbnails or cache/classifications don't exist, export should skip them gracefully, not fail.
+        let src = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"only db").unwrap();
+        // No cache/ tree at all.
+
+        let zip_path = out.path().join("catalog.zip");
+        let report = export_catalog_at(src.path(), &zip_path).unwrap();
+        assert_eq!(report.entries, 1, "should export exactly the DB file");
+    }
+
+    #[test]
+    fn export_catalog_refuses_overwrite_of_existing_zip() {
+        let src = tempdir().unwrap();
+        let out = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"x").unwrap();
+
+        let zip_path = out.path().join("catalog.zip");
+        fs::write(&zip_path, b"pre-existing").unwrap();
+
+        let err = export_catalog_at(src.path(), &zip_path);
+        assert!(err.is_err(), "should refuse to overwrite existing zip");
+    }
 }

--- a/sherlock/desktop/src-tauri/src/portability.rs
+++ b/sherlock/desktop/src-tauri/src/portability.rs
@@ -98,6 +98,93 @@ pub async fn export_catalog_cmd(
         .map_err(|e| e.to_string())
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportReport {
+    pub entries: usize,
+    pub bytes: u64,
+}
+
+/// Restore a catalog bundle (previously produced by `export_catalog_at`) into `base_dir`.
+///
+/// Refuses if `base_dir/db/index.sqlite` already exists (to avoid silently clobbering
+/// an active catalog). Rejects any zip entry whose path escapes `base_dir` via `..`
+/// components or absolute paths.
+pub fn import_catalog_at(bundle: &Path, base_dir: &Path) -> AppResult<ImportReport> {
+    use std::io::Read;
+
+    let db_target = base_dir.join("db").join("index.sqlite");
+    if db_target.exists() {
+        return Err(AppError::InvalidPath(format!(
+            "refusing to overwrite existing catalog at {}",
+            base_dir.display()
+        )));
+    }
+
+    let file = std::fs::File::open(bundle)
+        .map_err(|e| AppError::Config(format!("open bundle: {e}")))?;
+    let mut arch = zip::ZipArchive::new(file)
+        .map_err(|e| AppError::Config(format!("invalid zip: {e}")))?;
+
+    let mut entries = 0usize;
+    let mut bytes = 0u64;
+
+    for i in 0..arch.len() {
+        let mut zip_file = arch.by_index(i)
+            .map_err(|e| AppError::Config(format!("zip idx {i}: {e}")))?;
+        if zip_file.is_dir() {
+            continue;
+        }
+        // Defense against Zip-Slip.
+        let safe_rel = sanitize_zip_path(zip_file.name())
+            .ok_or_else(|| AppError::InvalidPath(format!(
+                "zip contains unsafe path: {}", zip_file.name()
+            )))?;
+
+        let target = base_dir.join(&safe_rel);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut buf = Vec::with_capacity(zip_file.size() as usize);
+        zip_file.read_to_end(&mut buf)
+            .map_err(|e| AppError::Config(format!("read {}: {e}", safe_rel.display())))?;
+        std::fs::write(&target, &buf)?;
+        entries += 1;
+        bytes += buf.len() as u64;
+    }
+
+    Ok(ImportReport { entries, bytes })
+}
+
+/// Reject absolute paths and any entry containing a `..` component. Returns the
+/// sanitized relative path on success, `None` on rejection.
+fn sanitize_zip_path(name: &str) -> Option<std::path::PathBuf> {
+    use std::path::{Component, PathBuf};
+    let p = PathBuf::from(name);
+    let mut cleaned = PathBuf::new();
+    for c in p.components() {
+        match c {
+            Component::Normal(n) => cleaned.push(n),
+            Component::CurDir => {}
+            // Any of these means the archive tries to escape the base_dir.
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        return None;
+    }
+    Some(cleaned)
+}
+
+#[tauri::command]
+pub async fn import_catalog_cmd(
+    state: tauri::State<'_, AppState>,
+    bundle: String,
+) -> Result<ImportReport, String> {
+    import_catalog_at(std::path::Path::new(&bundle), &state.paths.base_dir)
+        .map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod export_tests {
     use super::*;
@@ -158,5 +245,108 @@ mod export_tests {
 
         let err = export_catalog_at(src.path(), &zip_path);
         assert!(err.is_err(), "should refuse to overwrite existing zip");
+    }
+}
+
+#[cfg(test)]
+mod import_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn import_restores_db_and_caches() {
+        // Arrange: create + export.
+        let src = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"DBDATA").unwrap();
+        fs::create_dir_all(src.path().join("cache/thumbnails")).unwrap();
+        fs::write(src.path().join("cache/thumbnails/x.jpg"), b"T").unwrap();
+
+        let bundle = src.path().join("bundle.zip");
+        export_catalog_at(src.path(), &bundle).unwrap();
+
+        // Act: import into fresh directory.
+        let dst = tempdir().unwrap();
+        let report = import_catalog_at(&bundle, dst.path()).unwrap();
+
+        // Assert.
+        assert_eq!(fs::read(dst.path().join("db/index.sqlite")).unwrap(), b"DBDATA");
+        assert_eq!(fs::read(dst.path().join("cache/thumbnails/x.jpg")).unwrap(), b"T");
+        assert!(report.entries >= 2, "expected >=2 entries, got {}", report.entries);
+    }
+
+    #[test]
+    fn import_refuses_when_catalog_already_exists() {
+        // If db/index.sqlite already exists in the destination, refuse to clobber.
+        let src = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"X").unwrap();
+        let bundle = src.path().join("b.zip");
+        export_catalog_at(src.path(), &bundle).unwrap();
+
+        let dst = tempdir().unwrap();
+        fs::create_dir_all(dst.path().join("db")).unwrap();
+        fs::write(dst.path().join("db/index.sqlite"), b"EXISTING").unwrap();
+
+        let err = import_catalog_at(&bundle, dst.path());
+        assert!(err.is_err(), "should refuse to overwrite existing catalog");
+        // Verify pre-existing file was not clobbered.
+        assert_eq!(fs::read(dst.path().join("db/index.sqlite")).unwrap(), b"EXISTING");
+    }
+
+    #[test]
+    fn import_rejects_path_traversal() {
+        // Hand-craft a malicious zip with an entry like "../evil.txt".
+        use std::io::Write;
+        let tmp = tempdir().unwrap();
+        let bundle = tmp.path().join("evil.zip");
+        {
+            let f = fs::File::create(&bundle).unwrap();
+            let mut zw = zip::ZipWriter::new(f);
+            let opts: zip::write::FileOptions<()> =
+                zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            zw.start_file("../escaped.txt", opts).unwrap();
+            zw.write_all(b"pwned").unwrap();
+            zw.finish().unwrap();
+        }
+
+        let dst = tempdir().unwrap();
+        let err = import_catalog_at(&bundle, dst.path());
+        assert!(err.is_err(), "path traversal must be rejected");
+        // The parent of dst should not have been written to.
+        assert!(!dst.path().parent().unwrap().join("escaped.txt").exists());
+    }
+
+    #[test]
+    fn import_roundtrip_preserves_all_files() {
+        // End-to-end: export → import → byte-for-byte equivalence for every file.
+        let src = tempdir().unwrap();
+        fs::create_dir_all(src.path().join("db")).unwrap();
+        fs::write(src.path().join("db/index.sqlite"), b"db-bytes").unwrap();
+        fs::create_dir_all(src.path().join("cache/thumbnails/r/sub")).unwrap();
+        fs::write(src.path().join("cache/thumbnails/r/sub/a.jpg"), b"thumb-a").unwrap();
+        fs::write(src.path().join("cache/thumbnails/r/sub/b.jpg"), b"thumb-b").unwrap();
+        fs::create_dir_all(src.path().join("cache/classifications/r/sub")).unwrap();
+        fs::write(src.path().join("cache/classifications/r/sub/a.json"), b"{\"a\":1}").unwrap();
+
+        let bundle = src.path().join("bundle.zip");
+        export_catalog_at(src.path(), &bundle).unwrap();
+
+        let dst = tempdir().unwrap();
+        import_catalog_at(&bundle, dst.path()).unwrap();
+
+        for rel in [
+            "db/index.sqlite",
+            "cache/thumbnails/r/sub/a.jpg",
+            "cache/thumbnails/r/sub/b.jpg",
+            "cache/classifications/r/sub/a.json",
+        ] {
+            assert_eq!(
+                fs::read(src.path().join(rel)).unwrap(),
+                fs::read(dst.path().join(rel)).unwrap(),
+                "mismatch for {rel}"
+            );
+        }
     }
 }

--- a/sherlock/desktop/src-tauri/src/query_parser.rs
+++ b/sherlock/desktop/src-tauri/src/query_parser.rs
@@ -128,6 +128,17 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         working_query
     };
 
+    // Extract color:name|#RRGGBB
+    let mut color_hex: Option<u32> = None;
+    let color_re = Regex::new(r#"(?i)\bcolor:(\S+)"#).expect("valid regex");
+    let working_query = if let Some(cap) = color_re.captures(&working_query) {
+        let color_str = cap.get(1).map(|m| m.as_str()).unwrap_or_default();
+        color_hex = parse_color(color_str);
+        color_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
     let mut media_types = Vec::new();
     let mut min_confidence = None;
     let mut date_from = None;
@@ -184,6 +195,9 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
     if blur.is_some() {
         score += 0.1;
     }
+    if color_hex.is_some() {
+        score += 0.15;
+    }
 
     // Strip matched media keywords from query text, longest patterns first
     let mut query_text = working_query.clone();
@@ -212,7 +226,44 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         time_of_day,
         shot_kind,
         blur,
+        color_hex,
     }
+}
+
+/// Parse a color name or #RRGGBB hex string to a packed u32 (0x00RRGGBB).
+fn parse_color(s: &str) -> Option<u32> {
+    // Try hex format first: #RGB or #RRGGBB
+    let hex_str = s.strip_prefix('#').unwrap_or("");
+    if hex_str.len() == 6 {
+        if let Ok(v) = u32::from_str_radix(hex_str, 16) {
+            return Some(v);
+        }
+    } else if hex_str.len() == 3 {
+        // Expand #RGB → #RRGGBB
+        let expanded: String = hex_str.chars().flat_map(|c| [c, c]).collect();
+        if let Ok(v) = u32::from_str_radix(&expanded, 16) {
+            return Some(v);
+        }
+    }
+
+    // Named colors
+    let rgb = match s.to_lowercase().as_str() {
+        "red"    => (204u32, 34u32, 34u32),
+        "green"  => (34, 170, 34),
+        "blue"   => (34, 34, 204),
+        "yellow" => (204, 204, 34),
+        "orange" => (204, 136, 34),
+        "purple" => (136, 34, 153),
+        "pink"   => (204, 102, 136),
+        "brown"  => (153, 102, 51),
+        "teal"   => (34, 136, 136),
+        "cyan"   => (34, 170, 204),
+        "white"  => (238, 238, 238),
+        "black"  => (17, 17, 17),
+        "gray" | "grey" => (136, 136, 136),
+        _ => return None,
+    };
+    Some((rgb.0 << 16) | (rgb.1 << 8) | rgb.2)
 }
 
 fn parse_min_confidence(raw: &str) -> Option<f32> {

--- a/sherlock/desktop/src-tauri/src/query_parser.rs
+++ b/sherlock/desktop/src-tauri/src/query_parser.rs
@@ -107,6 +107,27 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         working_query
     };
 
+    // Extract shot:selfie|group|landscape
+    let mut shot_kind: Option<String> = None;
+    let shot_re = Regex::new(r#"(?i)\bshot:(\S+)"#).expect("valid regex");
+    let working_query = if let Some(cap) = shot_re.captures(&working_query) {
+        shot_kind = cap.get(1).map(|m| m.as_str().to_lowercase());
+        shot_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
+    // Extract blur:true|false
+    let mut blur: Option<bool> = None;
+    let blur_re = Regex::new(r#"(?i)\bblur:(true|false|yes|no|1|0)\b"#).expect("valid regex");
+    let working_query = if let Some(cap) = blur_re.captures(&working_query) {
+        let val = cap.get(1).map(|m| m.as_str().to_lowercase()).unwrap_or_default();
+        blur = Some(matches!(val.as_str(), "true" | "yes" | "1"));
+        blur_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
     let mut media_types = Vec::new();
     let mut min_confidence = None;
     let mut date_from = None;
@@ -157,6 +178,12 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
     if time_of_day.is_some() {
         score += 0.15;
     }
+    if shot_kind.is_some() {
+        score += 0.15;
+    }
+    if blur.is_some() {
+        score += 0.1;
+    }
 
     // Strip matched media keywords from query text, longest patterns first
     let mut query_text = working_query.clone();
@@ -183,6 +210,8 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         camera_model,
         lens_model,
         time_of_day,
+        shot_kind,
+        blur,
     }
 }
 

--- a/sherlock/desktop/src-tauri/src/query_parser.rs
+++ b/sherlock/desktop/src-tauri/src/query_parser.rs
@@ -77,6 +77,36 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         working_query
     };
 
+    // Extract camera:"model" or camera:model
+    let mut camera_model: Option<String> = None;
+    let camera_re = Regex::new(r#"(?i)\bcamera:(?:"([^"]+)"|(\S+))"#).expect("valid regex");
+    let working_query = if let Some(cap) = camera_re.captures(&working_query) {
+        camera_model = cap.get(1).or_else(|| cap.get(2)).map(|m| m.as_str().to_string());
+        camera_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
+    // Extract lens:"model" or lens:value
+    let mut lens_model: Option<String> = None;
+    let lens_re = Regex::new(r#"(?i)\blens:(?:"([^"]+)"|(\S+))"#).expect("valid regex");
+    let working_query = if let Some(cap) = lens_re.captures(&working_query) {
+        lens_model = cap.get(1).or_else(|| cap.get(2)).map(|m| m.as_str().to_string());
+        lens_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
+    // Extract time:value (night/dawn/morning/noon/afternoon/evening)
+    let mut time_of_day: Option<String> = None;
+    let time_re = Regex::new(r#"(?i)\btime:(\S+)"#).expect("valid regex");
+    let working_query = if let Some(cap) = time_re.captures(&working_query) {
+        time_of_day = cap.get(1).map(|m| m.as_str().to_lowercase());
+        time_re.replace(&working_query, "").trim().to_string()
+    } else {
+        working_query
+    };
+
     let mut media_types = Vec::new();
     let mut min_confidence = None;
     let mut date_from = None;
@@ -118,6 +148,15 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
     if person_id.is_some() || person_name.is_some() {
         score += 0.3;
     }
+    if camera_model.is_some() {
+        score += 0.2;
+    }
+    if lens_model.is_some() {
+        score += 0.2;
+    }
+    if time_of_day.is_some() {
+        score += 0.15;
+    }
 
     // Strip matched media keywords from query text, longest patterns first
     let mut query_text = working_query.clone();
@@ -141,6 +180,9 @@ pub fn parse_query(raw_query: &str) -> ParsedQuery {
         subdir,
         person_id,
         person_name,
+        camera_model,
+        lens_model,
+        time_of_day,
     }
 }
 
@@ -456,5 +498,39 @@ mod tests {
         let parsed = parse_query("beach sunset");
         assert!(parsed.person_id.is_none());
         assert!(parsed.person_name.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // camera:/lens:/time: prefix tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parses_camera_and_lens_and_time_tokens() {
+        let parsed = parse_query(r#"beach camera:"iPhone 14 Pro" lens:50mm time:evening"#);
+        assert_eq!(parsed.camera_model.as_deref(), Some("iPhone 14 Pro"));
+        assert_eq!(parsed.lens_model.as_deref(), Some("50mm"));
+        assert_eq!(parsed.time_of_day.as_deref(), Some("evening"));
+        assert_eq!(parsed.query_text.trim(), "beach");
+    }
+
+    #[test]
+    fn parses_camera_simple_token() {
+        let parsed = parse_query("camera:Canon sunset");
+        assert_eq!(parsed.camera_model.as_deref(), Some("Canon"));
+        assert_eq!(parsed.query_text.trim(), "sunset");
+    }
+
+    #[test]
+    fn parses_time_token_lowercases() {
+        let parsed = parse_query("time:Evening");
+        assert_eq!(parsed.time_of_day.as_deref(), Some("evening"));
+    }
+
+    #[test]
+    fn no_camera_or_lens_or_time() {
+        let parsed = parse_query("beach sunset");
+        assert!(parsed.camera_model.is_none());
+        assert!(parsed.lens_model.is_none());
+        assert!(parsed.time_of_day.is_none());
     }
 }

--- a/sherlock/desktop/src-tauri/src/scan.rs
+++ b/sherlock/desktop/src-tauri/src/scan.rs
@@ -542,6 +542,8 @@ struct ThumbnailOnlyResult {
     location_text: String,
     dhash: Option<u64>,
     blur_score: Option<f64>,
+    dominant_color: Option<i64>,
+    qr_codes: String,
     camera_model: String,
     lens_model: String,
     iso: Option<i64>,
@@ -599,9 +601,9 @@ fn thumbnail_only(ctx: &ScanContext, probe: &FileProbe) -> ThumbnailOnlyResult {
         crate::exif::extract_scan_exif(abs)
     };
 
-    let (thumb_path, dhash, blur_score) = match thumb_result {
-        Some(tr) => (Some(tr.path), tr.dhash, tr.blur_score),
-        None => (None, None, None),
+    let (thumb_path, dhash, blur_score, dominant_color, qr_codes) = match thumb_result {
+        Some(tr) => (Some(tr.path), tr.dhash, tr.blur_score, tr.dominant_color.map(|c| c as i64), tr.qr_codes),
+        None => (None, None, None, None, String::new()),
     };
 
     ThumbnailOnlyResult {
@@ -609,6 +611,8 @@ fn thumbnail_only(ctx: &ScanContext, probe: &FileProbe) -> ThumbnailOnlyResult {
         location_text: exif_location.location_text,
         dhash,
         blur_score,
+        dominant_color,
+        qr_codes,
         camera_model: exif_scan.camera_model,
         lens_model: exif_scan.lens_model,
         iso: exif_scan.iso,
@@ -673,6 +677,8 @@ fn probe_to_minimal_record(
         aperture: thumb_result.aperture,
         time_of_day: thumb_result.time_of_day.clone(),
         blur_score: thumb_result.blur_score,
+        dominant_color: thumb_result.dominant_color,
+        qr_codes: thumb_result.qr_codes.clone(),
     }
 }
 
@@ -1050,6 +1056,8 @@ mod tests {
             aperture: None,
             time_of_day: String::new(),
             blur_score: None,
+            dominant_color: None,
+            qr_codes: String::new(),
         };
         db::upsert_file_record(&db_path, &rec).expect("upsert");
 

--- a/sherlock/desktop/src-tauri/src/scan.rs
+++ b/sherlock/desktop/src-tauri/src/scan.rs
@@ -735,6 +735,12 @@ fn collect_image_probes_incremental(
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
+            // Never descend into our own portable catalog directory.
+            // In portable mode the catalog lives at <root>/.frank_sherlock/,
+            // so indexing it would cause the app to index its own state.
+            if is_portable_catalog_dir(e) {
+                return false;
+            }
             // Skip child root subtrees before descending
             if e.file_type().is_dir() && e.path() != root {
                 return !excluded_prefixes.iter().any(|p| e.path().starts_with(p));
@@ -897,6 +903,17 @@ fn fingerprint_file(path: &Path, size: u64) -> AppResult<String> {
     hasher.update(&tail);
 
     Ok(hex::encode(hasher.finalize()))
+}
+
+/// Returns true if the walkdir entry is the app's own portable catalog
+/// directory (`.frank_sherlock`), which must never be indexed.
+///
+/// In portable mode the catalog (db + thumbnail/classification caches) lives
+/// inside the scanned root under `.frank_sherlock/`. The scanner must skip
+/// that subtree or it would try to index its own SQLite file, cached
+/// thumbnails, etc.
+fn is_portable_catalog_dir(entry: &walkdir::DirEntry) -> bool {
+    entry.file_type().is_dir() && entry.file_name().to_str() == Some(".frank_sherlock")
 }
 
 fn is_supported_file(path: &Path) -> bool {
@@ -1179,5 +1196,94 @@ mod tests {
         assert!(!filenames.contains(&"spacer.gif"));
         assert!(!filenames.contains(&"favicon.png"));
         assert_eq!(probes.len(), 2);
+    }
+
+    #[test]
+    fn walker_skips_frank_sherlock_portable_dir() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        fs::write(root.join("photo.jpg"), b"\xFF\xD8\xFF\xE0fake jpeg header padding padding padding padding padding").unwrap();
+        fs::create_dir_all(root.join("subdir")).unwrap();
+        fs::write(root.join("subdir/more.png"), b"\x89PNG\r\n\x1A\nfake png bytes padding padding padding padding").unwrap();
+
+        // The portable catalog subtree — must be skipped entirely.
+        fs::create_dir_all(root.join(".frank_sherlock/db")).unwrap();
+        fs::write(root.join(".frank_sherlock/db/index.sqlite"), b"sqlite").unwrap();
+        fs::create_dir_all(root.join(".frank_sherlock/cache/thumbnails")).unwrap();
+        fs::write(root.join(".frank_sherlock/cache/thumbnails/x.jpg"), b"\xFF\xD8\xFF\xE0fake jpeg header padding padding padding padding padding").unwrap();
+
+        // Collect all file paths the walker would visit, mirroring the production
+        // `.filter_entry` logic using `is_portable_catalog_dir`.
+        let visited: Vec<std::path::PathBuf> = walkdir::WalkDir::new(root)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|e| !is_portable_catalog_dir(e))
+            .filter_map(|entry| entry.ok())
+            .filter(|e| e.file_type().is_file())
+            .map(|e| e.path().to_path_buf())
+            .collect();
+
+        let names: Vec<String> = visited
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            names.contains(&"photo.jpg".to_string()),
+            "expected to visit photo.jpg, got {names:?}"
+        );
+        assert!(
+            names.contains(&"more.png".to_string()),
+            "expected to visit more.png, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"index.sqlite".to_string()),
+            "must NOT visit files under .frank_sherlock, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"x.jpg".to_string()),
+            "must NOT visit files under .frank_sherlock, got {names:?}"
+        );
+    }
+
+    #[test]
+    fn is_portable_catalog_dir_recognises_dot_frank_sherlock() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".frank_sherlock")).unwrap();
+        std::fs::create_dir_all(dir.path().join("photos")).unwrap();
+        std::fs::write(
+            dir.path().join("a.jpg"),
+            b"padding padding padding padding padding padding",
+        )
+        .unwrap();
+
+        let entries: Vec<_> = walkdir::WalkDir::new(dir.path())
+            .min_depth(1)
+            .max_depth(1)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .collect();
+
+        let dot_fs = entries
+            .iter()
+            .find(|e| e.file_name().to_string_lossy() == ".frank_sherlock")
+            .expect("should find");
+        let photos = entries
+            .iter()
+            .find(|e| e.file_name().to_string_lossy() == "photos")
+            .expect("should find");
+        let a_jpg = entries
+            .iter()
+            .find(|e| e.file_name().to_string_lossy() == "a.jpg")
+            .expect("should find");
+
+        assert!(is_portable_catalog_dir(dot_fs));
+        assert!(!is_portable_catalog_dir(photos));
+        assert!(!is_portable_catalog_dir(a_jpg));
     }
 }

--- a/sherlock/desktop/src-tauri/src/scan.rs
+++ b/sherlock/desktop/src-tauri/src/scan.rs
@@ -541,6 +541,7 @@ struct ThumbnailOnlyResult {
     thumb_path: Option<String>,
     location_text: String,
     dhash: Option<u64>,
+    blur_score: Option<f64>,
     camera_model: String,
     lens_model: String,
     iso: Option<i64>,
@@ -598,15 +599,16 @@ fn thumbnail_only(ctx: &ScanContext, probe: &FileProbe) -> ThumbnailOnlyResult {
         crate::exif::extract_scan_exif(abs)
     };
 
-    let (thumb_path, dhash) = match thumb_result {
-        Some(tr) => (Some(tr.path), tr.dhash),
-        None => (None, None),
+    let (thumb_path, dhash, blur_score) = match thumb_result {
+        Some(tr) => (Some(tr.path), tr.dhash, tr.blur_score),
+        None => (None, None, None),
     };
 
     ThumbnailOnlyResult {
         thumb_path,
         location_text: exif_location.location_text,
         dhash,
+        blur_score,
         camera_model: exif_scan.camera_model,
         lens_model: exif_scan.lens_model,
         iso: exif_scan.iso,
@@ -670,6 +672,7 @@ fn probe_to_minimal_record(
         shutter_speed: thumb_result.shutter_speed,
         aperture: thumb_result.aperture,
         time_of_day: thumb_result.time_of_day.clone(),
+        blur_score: thumb_result.blur_score,
     }
 }
 
@@ -1046,6 +1049,7 @@ mod tests {
             shutter_speed: None,
             aperture: None,
             time_of_day: String::new(),
+            blur_score: None,
         };
         db::upsert_file_record(&db_path, &rec).expect("upsert");
 

--- a/sherlock/desktop/src-tauri/src/scan.rs
+++ b/sherlock/desktop/src-tauri/src/scan.rs
@@ -541,6 +541,12 @@ struct ThumbnailOnlyResult {
     thumb_path: Option<String>,
     location_text: String,
     dhash: Option<u64>,
+    camera_model: String,
+    lens_model: String,
+    iso: Option<i64>,
+    shutter_speed: Option<f64>,
+    aperture: Option<f64>,
+    time_of_day: String,
 }
 
 fn is_pdf_file(path: &Path) -> bool {
@@ -586,6 +592,12 @@ fn thumbnail_only(ctx: &ScanContext, probe: &FileProbe) -> ThumbnailOnlyResult {
         crate::exif::extract_location(abs)
     };
 
+    let exif_scan: crate::exif::ExifScanData = if is_pdf || is_vid {
+        Default::default()
+    } else {
+        crate::exif::extract_scan_exif(abs)
+    };
+
     let (thumb_path, dhash) = match thumb_result {
         Some(tr) => (Some(tr.path), tr.dhash),
         None => (None, None),
@@ -595,6 +607,12 @@ fn thumbnail_only(ctx: &ScanContext, probe: &FileProbe) -> ThumbnailOnlyResult {
         thumb_path,
         location_text: exif_location.location_text,
         dhash,
+        camera_model: exif_scan.camera_model,
+        lens_model: exif_scan.lens_model,
+        iso: exif_scan.iso,
+        shutter_speed: exif_scan.shutter_speed,
+        aperture: exif_scan.aperture,
+        time_of_day: exif_scan.time_of_day,
     }
 }
 
@@ -646,6 +664,12 @@ fn probe_to_minimal_record(
         video_height: video_meta.as_ref().and_then(|m| m.height),
         video_codec: video_meta.as_ref().and_then(|m| m.video_codec.clone()),
         audio_codec: video_meta.as_ref().and_then(|m| m.audio_codec.clone()),
+        camera_model: thumb_result.camera_model.clone(),
+        lens_model: thumb_result.lens_model.clone(),
+        iso: thumb_result.iso,
+        shutter_speed: thumb_result.shutter_speed,
+        aperture: thumb_result.aperture,
+        time_of_day: thumb_result.time_of_day.clone(),
     }
 }
 
@@ -1016,6 +1040,12 @@ mod tests {
             video_height: None,
             video_codec: None,
             audio_codec: None,
+            camera_model: String::new(),
+            lens_model: String::new(),
+            iso: None,
+            shutter_speed: None,
+            aperture: None,
+            time_of_day: String::new(),
         };
         db::upsert_file_record(&db_path, &rec).expect("upsert");
 

--- a/sherlock/desktop/src-tauri/src/scan.rs
+++ b/sherlock/desktop/src-tauri/src/scan.rs
@@ -177,6 +177,19 @@ fn run_scan_job_internal(
     let mut last_cursor: Option<String> = job.cursor_rel_path.clone();
     const UNCHANGED_BATCH_SIZE: usize = 200;
 
+    // Load enabled tag rules and compile their regexes once for the whole scan.
+    let compiled_tag_rules: Vec<(regex::Regex, String)> = {
+        let rules = db::get_enabled_tag_rules(db_path).unwrap_or_default();
+        rules
+            .into_iter()
+            .filter_map(|r| {
+                regex::Regex::new(&r.pattern)
+                    .ok()
+                    .map(|re| (re, r.tag))
+            })
+            .collect()
+    };
+
     // Determine whether to skip the thumbnailing phase (already done on a previous run).
     let skip_thumbnailing = job.phase == "classifying";
 
@@ -284,6 +297,7 @@ fn run_scan_job_internal(
                         probe,
                         &fingerprint,
                         &thumb_result,
+                        &compiled_tag_rules,
                     );
                     db::upsert_file_record(db_path, &record)?;
                     if let Some(ref thumb) = thumb_result.thumb_path {
@@ -369,6 +383,7 @@ fn run_scan_job_internal(
                         probe,
                         &fingerprint,
                         &thumb_result,
+                        &compiled_tag_rules,
                     );
                     db::upsert_file_record(db_path, &record)?;
                     if let Some(ref thumb) = thumb_result.thumb_path {
@@ -641,12 +656,22 @@ fn probe_to_minimal_record(
     probe: &FileProbe,
     fingerprint: &str,
     thumb_result: &ThumbnailOnlyResult,
+    tag_rules: &[(regex::Regex, String)],
 ) -> FileRecordUpsert {
     let video_meta = if video::is_video_file(Path::new(&probe.abs_path)) {
         video::extract_metadata(Path::new(&probe.abs_path))
     } else {
         None
     };
+
+    // Apply path-pattern tag rules to canonical_mentions.
+    let mut matched_tags: Vec<String> = Vec::new();
+    for (re, tag) in tag_rules {
+        if re.is_match(&probe.rel_path) && !matched_tags.contains(tag) {
+            matched_tags.push(tag.clone());
+        }
+    }
+    let canonical_mentions = matched_tags.join(",");
 
     FileRecordUpsert {
         root_id,
@@ -656,7 +681,7 @@ fn probe_to_minimal_record(
         media_type: infer_media_type_from_extension(&probe.filename).to_string(),
         description: String::new(),
         extracted_text: String::new(),
-        canonical_mentions: String::new(),
+        canonical_mentions,
         confidence: 0.0,
         lang_hint: String::new(),
         mtime_ns: probe.mtime_ns,

--- a/sherlock/desktop/src-tauri/src/thumbnail.rs
+++ b/sherlock/desktop/src-tauri/src/thumbnail.rs
@@ -11,6 +11,10 @@ pub struct ThumbnailResult {
     /// Blur/sharpness score (Laplacian variance). Higher = sharper.
     /// `Some` when the image was freshly decoded; `None` when cached.
     pub blur_score: Option<f64>,
+    /// Dominant color packed as 0x00RRGGBB. `Some` when freshly decoded.
+    pub dominant_color: Option<u32>,
+    /// Newline-separated decoded QR code payloads (empty = none found).
+    pub qr_codes: String,
 }
 
 /// Compute a 64-bit difference hash (dHash) from a decoded image.
@@ -76,6 +80,66 @@ pub fn compute_blur_score(img: &image::DynamicImage) -> f64 {
     }
 }
 
+/// Compute the dominant color of an image using fast histogram quantization.
+///
+/// Resizes to 32×32, quantizes each pixel to 4 bits per channel (16 levels),
+/// finds the most common quantized triplet, and returns the average RGB of that
+/// bucket packed as `0x00RRGGBB`.
+pub fn compute_dominant_color(img: &image::DynamicImage) -> u32 {
+    let small = img.resize_exact(32, 32, image::imageops::FilterType::Triangle);
+    let rgb = small.to_rgb8();
+
+    use std::collections::HashMap;
+    let mut counts: HashMap<(u8, u8, u8), (u32, u32, u32, u32)> = HashMap::new();
+
+    for pixel in rgb.pixels() {
+        let r = pixel.0[0];
+        let g = pixel.0[1];
+        let b = pixel.0[2];
+        let key = (r >> 4, g >> 4, b >> 4);
+        let entry = counts.entry(key).or_insert((0, 0, 0, 0));
+        entry.0 += 1;
+        entry.1 += r as u32;
+        entry.2 += g as u32;
+        entry.3 += b as u32;
+    }
+
+    if let Some((_, (cnt, sr, sg, sb))) = counts.iter().max_by_key(|(_, v)| v.0) {
+        let r = (sr / cnt) as u32;
+        let g = (sg / cnt) as u32;
+        let b = (sb / cnt) as u32;
+        (r << 16) | (g << 8) | b
+    } else {
+        0
+    }
+}
+
+/// Attempt to decode QR codes from an image.
+///
+/// Returns a newline-separated string of decoded payloads, or an empty string
+/// if no QR codes are found (or if decoding fails).
+pub fn decode_qr_codes(img: &image::DynamicImage) -> String {
+    let gray = img.to_luma8();
+    let (w, h) = gray.dimensions();
+    let mut prepared = rqrr::PreparedImage::prepare(gray);
+    let grids = prepared.detect_grids();
+
+    if grids.is_empty() || w < 10 || h < 10 {
+        return String::new();
+    }
+
+    let mut results: Vec<String> = Vec::new();
+    for grid in grids {
+        if let Ok((_, content)) = grid.decode() {
+            let trimmed = content.trim().to_string();
+            if !trimmed.is_empty() {
+                results.push(trimmed);
+            }
+        }
+    }
+    results.join("\n")
+}
+
 /// Generate a thumbnail for the given source image.
 ///
 /// Returns a `ThumbnailResult` with the path and optional dHash, or `None`
@@ -103,6 +167,8 @@ pub fn generate_thumbnail(
                     path: thumb_path.display().to_string(),
                     dhash: None,
                     blur_score: None,
+                    dominant_color: None,
+                    qr_codes: String::new(),
                 });
             }
         }
@@ -135,6 +201,8 @@ pub fn generate_thumbnail(
 
     let dhash = compute_dhash(&img);
     let blur_score = compute_blur_score(&img);
+    let dominant_color = compute_dominant_color(&img);
+    let qr_codes = decode_qr_codes(&img);
 
     let max_dim = 300u32;
     let (w, h) = (img.width(), img.height());
@@ -164,6 +232,8 @@ pub fn generate_thumbnail(
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
         blur_score: Some(blur_score),
+        dominant_color: Some(dominant_color),
+        qr_codes,
     })
 }
 
@@ -192,6 +262,8 @@ pub fn generate_pdf_thumbnail(
                     path: thumb_path.display().to_string(),
                     dhash: None,
                     blur_score: None,
+                    dominant_color: None,
+                    qr_codes: String::new(),
                 });
             }
         }
@@ -300,6 +372,8 @@ pub fn generate_pdf_thumbnail(
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
         blur_score: None,
+        dominant_color: None,
+        qr_codes: String::new(),
     })
 }
 
@@ -328,6 +402,8 @@ pub fn generate_video_thumbnail(
                     path: thumb_path.display().to_string(),
                     dhash: None,
                     blur_score: None,
+                    dominant_color: None,
+                    qr_codes: String::new(),
                 });
             }
         }
@@ -406,6 +482,8 @@ pub fn generate_video_thumbnail(
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
         blur_score: None,
+        dominant_color: None,
+        qr_codes: String::new(),
     })
 }
 

--- a/sherlock/desktop/src-tauri/src/thumbnail.rs
+++ b/sherlock/desktop/src-tauri/src/thumbnail.rs
@@ -8,6 +8,9 @@ pub struct ThumbnailResult {
     /// dHash computed from the image. `Some` when the thumbnail was freshly
     /// generated, `None` when the cached thumbnail was reused (image not decoded).
     pub dhash: Option<u64>,
+    /// Blur/sharpness score (Laplacian variance). Higher = sharper.
+    /// `Some` when the image was freshly decoded; `None` when cached.
+    pub blur_score: Option<f64>,
 }
 
 /// Compute a 64-bit difference hash (dHash) from a decoded image.
@@ -28,6 +31,49 @@ pub fn compute_dhash(img: &image::DynamicImage) -> u64 {
         }
     }
     hash
+}
+
+/// Compute a blur/sharpness score using the Laplacian variance method.
+///
+/// Downsizes the image to at most 512×512, converts to grayscale, then computes
+/// the mean squared Laplacian (4·p − left − right − up − down)² over all interior
+/// pixels.  Sharper images produce higher scores; very blurry images score near 0.
+pub fn compute_blur_score(img: &image::DynamicImage) -> f64 {
+    let (w, h) = (img.width(), img.height());
+    let max_dim = 512u32;
+    let small = if w > max_dim || h > max_dim {
+        let scale = max_dim as f64 / w.max(h) as f64;
+        let new_w = ((w as f64 * scale).round() as u32).max(1);
+        let new_h = ((h as f64 * scale).round() as u32).max(1);
+        img.resize_exact(new_w, new_h, image::imageops::FilterType::Triangle)
+    } else {
+        img.clone()
+    };
+
+    let gray = small.to_luma8();
+    let (gw, gh) = gray.dimensions();
+    if gw < 3 || gh < 3 {
+        return 0.0;
+    }
+
+    let mut sum_sq = 0.0f64;
+    let count = (gw - 2) as usize * (gh - 2) as usize;
+    for y in 1..(gh - 1) {
+        for x in 1..(gw - 1) {
+            let center = gray.get_pixel(x, y).0[0] as f64;
+            let left = gray.get_pixel(x - 1, y).0[0] as f64;
+            let right = gray.get_pixel(x + 1, y).0[0] as f64;
+            let up = gray.get_pixel(x, y - 1).0[0] as f64;
+            let down = gray.get_pixel(x, y + 1).0[0] as f64;
+            let lap = 4.0 * center - left - right - up - down;
+            sum_sq += lap * lap;
+        }
+    }
+    if count == 0 {
+        0.0
+    } else {
+        sum_sq / count as f64
+    }
 }
 
 /// Generate a thumbnail for the given source image.
@@ -56,6 +102,7 @@ pub fn generate_thumbnail(
                 return Some(ThumbnailResult {
                     path: thumb_path.display().to_string(),
                     dhash: None,
+                    blur_score: None,
                 });
             }
         }
@@ -87,6 +134,7 @@ pub fn generate_thumbnail(
     let img = crate::exif::apply_orientation(img, orientation);
 
     let dhash = compute_dhash(&img);
+    let blur_score = compute_blur_score(&img);
 
     let max_dim = 300u32;
     let (w, h) = (img.width(), img.height());
@@ -115,6 +163,7 @@ pub fn generate_thumbnail(
     Some(ThumbnailResult {
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
+        blur_score: Some(blur_score),
     })
 }
 
@@ -142,6 +191,7 @@ pub fn generate_pdf_thumbnail(
                 return Some(ThumbnailResult {
                     path: thumb_path.display().to_string(),
                     dhash: None,
+                    blur_score: None,
                 });
             }
         }
@@ -249,6 +299,7 @@ pub fn generate_pdf_thumbnail(
     Some(ThumbnailResult {
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
+        blur_score: None,
     })
 }
 
@@ -276,6 +327,7 @@ pub fn generate_video_thumbnail(
                 return Some(ThumbnailResult {
                     path: thumb_path.display().to_string(),
                     dhash: None,
+                    blur_score: None,
                 });
             }
         }
@@ -353,6 +405,7 @@ pub fn generate_video_thumbnail(
     Some(ThumbnailResult {
         path: thumb_path.display().to_string(),
         dhash: Some(dhash),
+        blur_score: None,
     })
 }
 
@@ -453,6 +506,80 @@ mod tests {
         assert!(result.is_some());
         let thumb_img = image::open(result.unwrap().path).expect("open");
         assert_eq!(thumb_img.width(), 100);
+    }
+
+    #[test]
+    fn blur_score_sharp_image_higher_than_blurry() {
+        let src_dir = tempfile::tempdir().expect("tempdir");
+        // Sharp: high-contrast checkerboard
+        let sharp_path = src_dir.path().join("sharp.png");
+        let sharp_img = image::RgbImage::from_fn(200, 200, |x, y| {
+            if (x / 8 + y / 8) % 2 == 0 {
+                image::Rgb([255u8, 255, 255])
+            } else {
+                image::Rgb([0u8, 0, 0])
+            }
+        });
+        image::DynamicImage::ImageRgb8(sharp_img.clone())
+            .save(&sharp_path)
+            .unwrap();
+
+        // Blurry: solid gray (no edges)
+        let blurry_path = src_dir.path().join("blurry.png");
+        let blurry_img = image::RgbImage::from_pixel(200, 200, image::Rgb([128u8, 128, 128]));
+        image::DynamicImage::ImageRgb8(blurry_img)
+            .save(&blurry_path)
+            .unwrap();
+
+        let sharp_dyn = image::open(&sharp_path).unwrap();
+        let blurry_dyn = image::open(&blurry_path).unwrap();
+        let sharp_score = compute_blur_score(&sharp_dyn);
+        let blurry_score = compute_blur_score(&blurry_dyn);
+        assert!(
+            sharp_score > blurry_score,
+            "sharp={sharp_score} should be > blurry={blurry_score}"
+        );
+        assert_eq!(blurry_score, 0.0, "solid gray has no Laplacian response");
+    }
+
+    #[test]
+    fn blur_score_tiny_image_returns_zero() {
+        let img = image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            2,
+            2,
+            image::Rgb([128u8, 128, 128]),
+        ));
+        assert_eq!(compute_blur_score(&img), 0.0);
+    }
+
+    #[test]
+    fn thumbnail_result_has_blur_score_for_fresh_image() {
+        let src_dir = tempfile::tempdir().expect("tempdir");
+        let thumb_dir = tempfile::tempdir().expect("tempdir");
+        let source = create_test_image(src_dir.path(), "blur_test.png", 300, 300);
+        let result = generate_thumbnail(&source, thumb_dir.path(), "blur_test.png");
+        assert!(result.is_some());
+        let tr = result.unwrap();
+        assert!(
+            tr.blur_score.is_some(),
+            "fresh thumbnail should have blur_score"
+        );
+    }
+
+    #[test]
+    fn thumbnail_result_no_blur_score_for_cached() {
+        let src_dir = tempfile::tempdir().expect("tempdir");
+        let thumb_dir = tempfile::tempdir().expect("tempdir");
+        let source = create_test_image(src_dir.path(), "cache_blur.png", 300, 300);
+        // Generate once
+        let _r1 = generate_thumbnail(&source, thumb_dir.path(), "cache_blur.png");
+        // Second call should reuse cache → blur_score None
+        let r2 = generate_thumbnail(&source, thumb_dir.path(), "cache_blur.png");
+        assert!(r2.is_some());
+        assert!(
+            r2.unwrap().blur_score.is_none(),
+            "cached thumbnail should have no blur_score"
+        );
     }
 
     #[test]

--- a/sherlock/desktop/src-tauri/src/timeline.rs
+++ b/sherlock/desktop/src-tauri/src/timeline.rs
@@ -1,0 +1,120 @@
+//! Timeline density aggregation — monthly photo-count buckets for the heatmap sidebar.
+use crate::db::open_conn;
+use crate::error::AppResult;
+use std::path::Path;
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineBucket {
+    /// ISO-8601 month string, e.g. "2023-06"
+    pub bucket: String,
+    pub count: i64,
+}
+
+pub fn list_timeline_buckets(db_path: &Path) -> AppResult<Vec<TimelineBucket>> {
+    let conn = open_conn(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT strftime('%Y-%m', datetime(mtime_ns / 1000000000, 'unixepoch')) AS bucket,
+                COUNT(*) AS c
+         FROM files
+         WHERE deleted_at IS NULL
+           AND mtime_ns IS NOT NULL
+           AND mtime_ns > 0
+         GROUP BY bucket
+         ORDER BY bucket ASC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(TimelineBucket { bucket: r.get(0)?, count: r.get(1)? })
+    })?;
+    Ok(rows.filter_map(Result::ok).collect())
+}
+
+#[tauri::command]
+pub async fn list_timeline_buckets_cmd(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<Vec<TimelineBucket>, String> {
+    list_timeline_buckets(&state.paths.db_file).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{init_database, upsert_root};
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    fn insert_file(conn: &Connection, root_id: i64, filename: &str, mtime_ns: i64) {
+        conn.execute(
+            "INSERT INTO files
+               (root_id, rel_path, filename, abs_path, mtime_ns, size_bytes, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, 0)",
+            rusqlite::params![
+                root_id,
+                filename,
+                filename,
+                format!("/tmp/{filename}"),
+                mtime_ns,
+                format!("fp-{filename}"),
+            ],
+        )
+        .unwrap();
+    }
+
+    // 2023-01-15 00:00:00 UTC in ns
+    const JAN_2023: i64 = 1673740800_i64 * 1_000_000_000;
+    // 2023-06-20 00:00:00 UTC in ns
+    const JUN_2023: i64 = 1687219200_i64 * 1_000_000_000;
+    // 2024-03-10 00:00:00 UTC in ns
+    const MAR_2024: i64 = 1710028800_i64 * 1_000_000_000;
+
+    #[test]
+    fn groups_by_month_ascending() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        insert_file(&conn, root, "a.jpg", JAN_2023);
+        insert_file(&conn, root, "b.jpg", JAN_2023);
+        insert_file(&conn, root, "c.jpg", JUN_2023);
+        insert_file(&conn, root, "d.jpg", MAR_2024);
+        drop(conn);
+
+        let out = list_timeline_buckets(&db).unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].bucket, "2023-01");
+        assert_eq!(out[0].count, 2);
+        assert_eq!(out[1].bucket, "2023-06");
+        assert_eq!(out[1].count, 1);
+        assert_eq!(out[2].bucket, "2024-03");
+        assert_eq!(out[2].count, 1);
+    }
+
+    #[test]
+    fn skips_deleted_files() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let root = upsert_root(&db, "/tmp").unwrap();
+        let conn = Connection::open(&db).unwrap();
+        insert_file(&conn, root, "a.jpg", JAN_2023);
+        conn.execute(
+            "UPDATE files SET deleted_at = 1 WHERE filename = 'a.jpg'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let out = list_timeline_buckets(&db).unwrap();
+        assert!(out.is_empty(), "deleted files should not appear in timeline");
+    }
+
+    #[test]
+    fn empty_db_returns_empty_vec() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("t.sqlite");
+        init_database(&db).unwrap();
+        let out = list_timeline_buckets(&db).unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -33,6 +33,8 @@ import ScanSummaryModal from "./components/modals/ScanSummaryModal";
 import PreviewModal from "./components/modals/PreviewModal";
 import ConfirmDeleteModal from "./components/modals/ConfirmDeleteModal";
 import RemapRootModal from "./components/modals/RemapRootModal";
+import ExportCatalogModal from "./components/modals/ExportCatalogModal";
+import ImportCatalogModal from "./components/modals/ImportCatalogModal";
 import ConfirmFileDeleteModal from "./components/modals/ConfirmFileDeleteModal";
 import RenameModal from "./components/modals/RenameModal";
 import HelpModal from "./components/modals/HelpModal";
@@ -88,6 +90,8 @@ export default function App() {
   const [forceShowSetup, setForceShowSetup] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [pdfPasswordsMode, setPdfPasswordsMode] = useState(false);
+  const [showExportCatalog, setShowExportCatalog] = useState(false);
+  const [showImportCatalog, setShowImportCatalog] = useState(false);
 
   /* ── Directory tree: derived from query ── */
   const selectedSubdir = useMemo(() => {
@@ -615,6 +619,12 @@ export default function App() {
           onConfirm={onDeleteRoot}
         />
       )}
+      {showExportCatalog && (
+        <ExportCatalogModal onClose={() => setShowExportCatalog(false)} />
+      )}
+      {showImportCatalog && (
+        <ImportCatalogModal onClose={() => setShowImportCatalog(false)} />
+      )}
       {remapTargetRoot && (
         <RemapRootModal
           oldPath={remapTargetRoot.rootPath}
@@ -757,6 +767,8 @@ export default function App() {
           onFindDuplicates={enterDuplicatesMode}
           onOpenPdfPasswords={enterPdfPasswordsMode}
           onOpenFaces={enterFacesMode}
+          onExportCatalog={() => setShowExportCatalog(true)}
+          onImportCatalog={() => setShowImportCatalog(true)}
           updateInfo={autoUpdate.updateInfo}
           updateChecking={autoUpdate.updateChecking}
           updateDownloading={autoUpdate.updateDownloading}

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
-  cancelScan, copyFilesToClipboard, createFaceSmartAlbum, deleteFiles, ensureDatabase,
-  generateYearReview, getCliFolderPath, getFileMetadata, getFileProperties, listRoots,
-  removeRoot, renameFile, reorderRoots, startScan, updateFileMetadata,
+  cancelScan, copyFilesToClipboard, createFaceSmartAlbum, createSavedSearch, deleteFiles,
+  deleteSavedSearch, ensureDatabase, generateYearReview, getCliFolderPath, getFileMetadata,
+  getFileProperties, listRoots, listSavedSearches, removeRoot, renameFile, reorderRoots,
+  setSavedSearchNotify, startScan, updateFileMetadata,
 } from "./api";
 import type {
   DbStats,
@@ -11,8 +12,10 @@ import type {
   FileMetadata,
   RootInfo,
   RuntimeStatus,
+  SavedSearch,
   SearchItem,
   SetupStatus,
+  SimilarResult,
   SortField,
   SortOrder,
 } from "./types";
@@ -96,6 +99,7 @@ export default function App() {
   const [showExportCatalog, setShowExportCatalog] = useState(false);
   const [showImportCatalog, setShowImportCatalog] = useState(false);
   const [showTagRules, setShowTagRules] = useState(false);
+  const [savedSearches, setSavedSearches] = useState<SavedSearch[]>([]);
 
   /* ── Directory tree: derived from query ── */
   const selectedSubdir = useMemo(() => {
@@ -181,11 +185,19 @@ export default function App() {
     itemsLength: () => items.length,
   });
 
+  const refreshSavedSearches = useCallback(async () => {
+    try {
+      const searches = await listSavedSearches();
+      setSavedSearches(searches);
+    } catch { /* ignore */ }
+  }, []);
+
   /* ── Init app: also load albums + smart folders + CLI folder ── */
   const initApp = useCallback(async () => {
     const result = await scanManager.initApp();
     await albumManager.refreshAlbums();
     await smartFolderManager.refreshSmartFolders();
+    await refreshSavedSearches();
 
     if (!result) return;
     const cliPath = await getCliFolderPath();
@@ -220,7 +232,7 @@ export default function App() {
         if (newRoot) setSelectedRootId(newRoot.id);
       } catch { /* ignore */ }
     }
-  }, [scanManager.initApp]);
+  }, [scanManager.initApp, refreshSavedSearches]);
 
   useAppInit(initApp);
   usePolling(POLL_MS, scanManager.pollRuntimeAndScans, [scanManager.trackedJobIds]);
@@ -549,6 +561,18 @@ export default function App() {
     smartFolderManager.onCreateSmartFolderConfirm(name, query);
   }
 
+  async function handleSaveSearch() {
+    const name = window.prompt("Save search as:", query.trim().slice(0, 40) || "My Search");
+    if (!name || !name.trim()) return;
+    try {
+      await createSavedSearch(name.trim(), query.trim());
+      await refreshSavedSearches();
+      setNotice(`Saved search "${name.trim()}"`);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  }
+
   /* ── Duplicates handler wrappers ── */
   function handleDuplicatesDeleteSelected() {
     const filesToDelete = duplicates.getDeleteSearchItems();
@@ -596,6 +620,28 @@ export default function App() {
           totalItems={items.length}
           onClose={() => setPreviewOpen(false)}
           onNavigate={(idx) => { selectOnly(idx); }}
+          onNavigateSimilar={(result: SimilarResult) => {
+            // If the similar file is already in the results list, navigate there
+            const idx = items.findIndex((it) => it.id === result.fileId);
+            if (idx >= 0) {
+              selectOnly(idx);
+            } else {
+              // Synthesize a minimal SearchItem for standalone preview
+              const synth: SearchItem = {
+                id: result.fileId,
+                rootId: result.rootId,
+                relPath: result.relPath,
+                absPath: result.absPath,
+                mediaType: result.mediaType,
+                description: result.description,
+                confidence: result.score,
+                mtimeNs: 0,
+                sizeBytes: 0,
+                thumbnailPath: result.thumbPath,
+              };
+              setFacePreviewItems([synth]);
+            }
+          }}
         />
       )}
       {duplicates.dupPreviewItems.length > 0 && (
@@ -820,6 +866,30 @@ export default function App() {
             });
             smartFolderManager.setActiveSmartFolderId(null);
           }}
+          savedSearches={savedSearches}
+          onSelectSavedSearch={(s) => {
+            setQuery(s.query);
+            smartFolderManager.setActiveSmartFolderId(null);
+            duplicates.setDuplicatesMode(false);
+            setPdfPasswordsMode(false);
+            faces.setFacesMode(false);
+          }}
+          onDeleteSavedSearch={async (s) => {
+            try {
+              await deleteSavedSearch(s.id);
+              await refreshSavedSearches();
+            } catch (err) {
+              setError(errorMessage(err));
+            }
+          }}
+          onToggleSavedSearchNotify={async (s) => {
+            try {
+              await setSavedSearchNotify(s.id, !s.notify);
+              await refreshSavedSearches();
+            } catch (err) {
+              setError(errorMessage(err));
+            }
+          }}
         />
 
         {faces.facesMode ? (
@@ -907,6 +977,7 @@ export default function App() {
             onSortOrderChange={setSortOrder}
             hasTextQuery={query.trim().length > 0}
             onSaveSmartFolder={smartFolderManager.openCreateModal}
+            onSaveSearch={handleSaveSearch}
             items={items}
             total={total}
             loading={loading}

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
-  cancelScan, copyFilesToClipboard, deleteFiles, ensureDatabase,
+  cancelScan, copyFilesToClipboard, createFaceSmartAlbum, deleteFiles, ensureDatabase,
   generateYearReview, getCliFolderPath, getFileMetadata, getFileProperties, listRoots,
   removeRoot, renameFile, reorderRoots, startScan, updateFileMetadata,
 } from "./api";
@@ -44,6 +44,7 @@ import SimilarResultsModal from "./components/modals/SimilarResultsModal";
 import ModelInfoModal from "./components/modals/ModelInfoModal";
 import CreateAlbumModal from "./components/modals/CreateAlbumModal";
 import CreateSmartFolderModal from "./components/modals/CreateSmartFolderModal";
+import TagRulesModal from "./components/modals/TagRulesModal";
 import { useToast } from "./hooks/useToast";
 import { useUserConfig } from "./hooks/useUserConfig";
 import { useGridColumns } from "./hooks/useGridColumns";
@@ -94,6 +95,7 @@ export default function App() {
   const [pdfPasswordsMode, setPdfPasswordsMode] = useState(false);
   const [showExportCatalog, setShowExportCatalog] = useState(false);
   const [showImportCatalog, setShowImportCatalog] = useState(false);
+  const [showTagRules, setShowTagRules] = useState(false);
 
   /* ── Directory tree: derived from query ── */
   const selectedSubdir = useMemo(() => {
@@ -636,6 +638,7 @@ export default function App() {
       {showImportCatalog && (
         <ImportCatalogModal onClose={() => setShowImportCatalog(false)} />
       )}
+      {showTagRules && <TagRulesModal onClose={() => setShowTagRules(false)} />}
       {remapTargetRoot && (
         <RemapRootModal
           oldPath={remapTargetRoot.rootPath}
@@ -798,6 +801,7 @@ export default function App() {
               setError(errorMessage(err));
             }
           }}
+          onOpenTagRules={() => setShowTagRules(true)}
           onOpenPdfPasswords={enterPdfPasswordsMode}
           onOpenFaces={enterFacesMode}
           onExportCatalog={() => setShowExportCatalog(true)}
@@ -850,6 +854,15 @@ export default function App() {
             }}
             onNotice={setNotice}
             onError={setError}
+            onCreateFaceSmartAlbum={async (personName) => {
+              try {
+                const folder = await createFaceSmartAlbum(personName);
+                setNotice(`Smart album "${folder.name}" created`);
+                await smartFolderManager.refreshSmartFolders();
+              } catch (err) {
+                setError(errorMessage(err));
+              }
+            }}
           />
         ) : pdfPasswordsMode ? (
           <PdfPasswordsView

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -794,6 +794,14 @@ export default function App() {
           updateProgress={autoUpdate.updateProgress}
           onCheckUpdates={() => autoUpdate.checkForUpdates(false)}
           onInstallUpdate={autoUpdate.installUpdate}
+          onTimelineQueryChange={(dateRange) => {
+            setQuery((q) => {
+              // Replace any existing date range and append the new one
+              const stripped = q.replace(/\d{4}-\d{2}-\d{2}\s+\d{4}-\d{2}-\d{2}/g, "").trim();
+              return dateRange ? `${dateRange}${stripped ? " " + stripped : ""}` : stripped;
+            });
+            smartFolderManager.setActiveSmartFolderId(null);
+          }}
         />
 
         {faces.facesMode ? (

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -37,6 +37,7 @@ import RenameModal from "./components/modals/RenameModal";
 import HelpModal from "./components/modals/HelpModal";
 import EditMetadataModal from "./components/modals/EditMetadataModal";
 import PropertiesModal from "./components/modals/PropertiesModal";
+import SimilarResultsModal from "./components/modals/SimilarResultsModal";
 import ModelInfoModal from "./components/modals/ModelInfoModal";
 import CreateAlbumModal from "./components/modals/CreateAlbumModal";
 import CreateSmartFolderModal from "./components/modals/CreateSmartFolderModal";
@@ -83,6 +84,7 @@ export default function App() {
   const [editMetadataItem, setEditMetadataItem] = useState<SearchItem | null>(null);
   const [facePreviewItems, setFacePreviewItems] = useState<SearchItem[]>([]);
   const [propertiesItem, setPropertiesItem] = useState<SearchItem | null>(null);
+  const [similarSource, setSimilarSource] = useState<{ fileId: number; label: string } | null>(null);
   const [forceShowSetup, setForceShowSetup] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [pdfPasswordsMode, setPdfPasswordsMode] = useState(false);
@@ -437,6 +439,15 @@ export default function App() {
     if (idx < items.length) setPropertiesItem(items[idx]);
   }
 
+  function handleContextFindSimilar() {
+    setContextMenu(null);
+    if (selectedIndices.size !== 1) return;
+    const idx = [...selectedIndices][0];
+    if (idx >= items.length) return;
+    const item = items[idx];
+    setSimilarSource({ fileId: item.id, label: fileName(item.relPath) });
+  }
+
   async function handleDeleteFiles() {
     if (!confirmDeleteFiles) return;
     const ids = confirmDeleteFiles.map(f => f.id);
@@ -642,6 +653,7 @@ export default function App() {
           onRename={handleContextRename}
           onEditMetadata={handleContextEditMetadata}
           onProperties={handleContextProperties}
+          onFindSimilar={handleContextFindSimilar}
           onDelete={handleContextDelete}
           onAddToAlbum={handleAddToAlbum}
           onCreateAlbumFromSelection={handleCreateAlbumFromSelection}
@@ -659,6 +671,13 @@ export default function App() {
         <PropertiesModal
           fileId={propertiesItem.id}
           onClose={() => setPropertiesItem(null)}
+        />
+      )}
+      {similarSource && (
+        <SimilarResultsModal
+          sourceFileId={similarSource.fileId}
+          sourceLabel={similarSource.label}
+          onClose={() => setSimilarSource(null)}
         />
       )}
       {albumManager.showCreateAlbum && (

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   cancelScan, copyFilesToClipboard, deleteFiles, ensureDatabase,
-  getCliFolderPath, getFileMetadata, getFileProperties, listRoots,
+  generateYearReview, getCliFolderPath, getFileMetadata, getFileProperties, listRoots,
   removeRoot, renameFile, reorderRoots, startScan, updateFileMetadata,
 } from "./api";
 import type {
@@ -784,6 +784,20 @@ export default function App() {
           onDetectFaces={faces.onDetectFaces}
           onCancelFaceDetect={faces.onCancelFaceDetect}
           onFindDuplicates={enterDuplicatesMode}
+          onGenerateYearReview={async () => {
+            try {
+              const year = new Date().getFullYear();
+              const albumId = await generateYearReview(year);
+              if (albumId > 0) {
+                setNotice(`Year in Review ${year} album created!`);
+                await albumManager.refreshAlbums();
+              } else {
+                setNotice(`No photos found for ${year}.`);
+              }
+            } catch (err) {
+              setError(errorMessage(err));
+            }
+          }}
           onOpenPdfPasswords={enterPdfPasswordsMode}
           onOpenFaces={enterFacesMode}
           onExportCatalog={() => setShowExportCatalog(true)}
@@ -859,6 +873,13 @@ export default function App() {
             onBack={duplicates.onBack}
             onSelectGroupDuplicates={duplicates.onSelectGroupDuplicates}
             onPreviewGroup={handleDuplicatesPreviewGroup}
+            onApplyDedupPolicy={async (strategy) => {
+              const { setDedupPolicy, applyDedupPolicy } = await import("./api");
+              await setDedupPolicy(strategy);
+              const count = await applyDedupPolicy();
+              setNotice(`Policy applied: ${count} file(s) marked for deletion.`);
+              await duplicates.refreshAfterDelete();
+            }}
           />
         ) : (
           <Content

--- a/sherlock/desktop/src/App.tsx
+++ b/sherlock/desktop/src/App.tsx
@@ -32,6 +32,7 @@ import ResumeModal from "./components/modals/ResumeModal";
 import ScanSummaryModal from "./components/modals/ScanSummaryModal";
 import PreviewModal from "./components/modals/PreviewModal";
 import ConfirmDeleteModal from "./components/modals/ConfirmDeleteModal";
+import RemapRootModal from "./components/modals/RemapRootModal";
 import ConfirmFileDeleteModal from "./components/modals/ConfirmFileDeleteModal";
 import RenameModal from "./components/modals/RenameModal";
 import HelpModal from "./components/modals/HelpModal";
@@ -73,6 +74,7 @@ export default function App() {
   const [readOnly, setReadOnly] = useState(false);
   const [showResumeModal, setShowResumeModal] = useState(false);
   const [confirmDeleteRoot, setConfirmDeleteRoot] = useState<RootInfo | null>(null);
+  const [remapTargetRoot, setRemapTargetRoot] = useState<RootInfo | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
@@ -613,6 +615,17 @@ export default function App() {
           onConfirm={onDeleteRoot}
         />
       )}
+      {remapTargetRoot && (
+        <RemapRootModal
+          oldPath={remapTargetRoot.rootPath}
+          onClose={() => setRemapTargetRoot(null)}
+          onRemapped={() => {
+            setNotice(`Remapped "${remapTargetRoot.rootName}"`);
+            void scanManager.refreshRoots();
+            setRemapTargetRoot(null);
+          }}
+        />
+      )}
       {confirmDeleteFiles && (
         <ConfirmFileDeleteModal
           files={confirmDeleteFiles}
@@ -727,6 +740,7 @@ export default function App() {
             copyFilesToClipboard([root.rootPath]).catch(() => {});
             setNotice(`Copied path: ${root.rootPath}`);
           }}
+          onRemapRoot={(root) => setRemapTargetRoot(root)}
           onPickAndScan={() => scanManager.onPickAndScan(setup, readOnly)}
           onCancelScan={(scan) => scanManager.onCancelScan(scan, readOnly)}
           onResumeScan={(scan) => scanManager.onResumeScan(scan, readOnly)}

--- a/sherlock/desktop/src/__tests__/components/ChipSearchBar.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/ChipSearchBar.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChipSearchBar from "../../components/Search/ChipSearchBar";
+
+// Mock the api suggest call so TagAutocomplete doesn't hit Tauri
+vi.mock("../../api", () => ({
+  suggestTags: vi.fn().mockResolvedValue([]),
+}));
+
+describe("ChipSearchBar", () => {
+  it("renders with placeholder when no query", () => {
+    render(<ChipSearchBar query="" onQueryChange={() => {}} placeholder="Search…" />);
+    expect(screen.getByPlaceholderText("Search…")).toBeInTheDocument();
+  });
+
+  it("shows free text from initial query", () => {
+    render(<ChipSearchBar query="beach sunset" onQueryChange={() => {}} />);
+    expect(screen.getByDisplayValue("beach sunset")).toBeInTheDocument();
+  });
+
+  it("parses camera chip from initial query", () => {
+    render(<ChipSearchBar query="camera:Sony beach" onQueryChange={() => {}} />);
+    expect(screen.getByText("Sony")).toBeInTheDocument();
+    expect(screen.getByText(/Camera/i)).toBeInTheDocument();
+  });
+
+  it("deletes a chip when × is clicked", async () => {
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    render(<ChipSearchBar query='camera:"Canon R5"' onQueryChange={onQueryChange} />);
+    const deleteBtn = screen.getByLabelText(/Remove camera filter/i);
+    await user.click(deleteBtn);
+    // After delete, the serialised query should not contain camera:
+    const lastCall = onQueryChange.mock.calls.at(-1)?.[0] as string;
+    expect(lastCall).not.toContain("camera:");
+  });
+
+  it("opens facet menu when + button clicked", async () => {
+    const user = userEvent.setup();
+    render(<ChipSearchBar query="" onQueryChange={() => {}} />);
+    await user.click(screen.getByLabelText("Add filter"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Camera" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Lens" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Time" })).toBeInTheDocument();
+  });
+
+  it("starts a pending chip when a facet is selected from menu", async () => {
+    const user = userEvent.setup();
+    render(<ChipSearchBar query="" onQueryChange={() => {}} />);
+    await user.click(screen.getByLabelText("Add filter"));
+    await user.click(screen.getByRole("menuitem", { name: "Camera" }));
+    // A pending chip input should be visible
+    expect(screen.getByLabelText(/camera filter value/i)).toBeInTheDocument();
+  });
+
+  it("emits serialized query when free text is typed", async () => {
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    render(<ChipSearchBar query="" onQueryChange={onQueryChange} />);
+    const input = screen.getByRole("searchbox");
+    await user.type(input, "hello");
+    // onQueryChange should have been called with the accumulated text
+    const lastCall = onQueryChange.mock.calls.at(-1)?.[0] as string;
+    expect(lastCall).toContain("hello");
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/ContextMenu.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/ContextMenu.test.tsx
@@ -18,6 +18,7 @@ const baseProps = {
   onRename: vi.fn(),
   onEditMetadata: vi.fn(),
   onProperties: vi.fn(),
+  onFindSimilar: vi.fn(),
   onDelete: vi.fn(),
   onAddToAlbum: vi.fn(),
   onCreateAlbumFromSelection: vi.fn(),
@@ -151,5 +152,18 @@ describe("ContextMenu", () => {
     render(<ContextMenu {...baseProps} selectedCount={1} extractedText="ocr" onCopyOcrText={onCopyOcrText} />);
     await user.click(screen.getByText("Copy OCR Text"));
     expect(onCopyOcrText).toHaveBeenCalledOnce();
+  });
+
+  it("renders Find similar when exactly one item is selected", () => {
+    const onFindSimilar = vi.fn();
+    render(<ContextMenu {...baseProps} selectedCount={1} onFindSimilar={onFindSimilar} />);
+    const btn = screen.getByRole("menuitem", { name: /find similar/i });
+    btn.click();
+    expect(onFindSimilar).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Find similar when multiple items are selected", () => {
+    render(<ContextMenu {...baseProps} selectedCount={3} onFindSimilar={vi.fn()} />);
+    expect(screen.queryByRole("menuitem", { name: /find similar/i })).not.toBeInTheDocument();
   });
 });

--- a/sherlock/desktop/src/__tests__/components/ExportCatalogModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/ExportCatalogModal.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ExportCatalogModal from "../../components/modals/ExportCatalogModal";
+
+const invokeMock = vi.fn();
+const saveMock = vi.fn();
+const openPathMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: (...args: unknown[]) => saveMock(...args),
+  open: vi.fn(),
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openPath: (...args: unknown[]) => openPathMock(...args),
+  openUrl: vi.fn(),
+}));
+
+describe("ExportCatalogModal", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    saveMock.mockReset();
+    openPathMock.mockReset();
+  });
+
+  it("cancels when user dismisses the save dialog", async () => {
+    saveMock.mockResolvedValue(null);
+    const onClose = vi.fn();
+    render(<ExportCatalogModal onClose={onClose} />);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("exports and surfaces the count and byte size", async () => {
+    saveMock.mockResolvedValue("C:\\Users\\me\\catalog.zip");
+    invokeMock.mockResolvedValue({ zipPath: "C:\\Users\\me\\catalog.zip", entries: 123, bytes: 4567890 });
+    render(<ExportCatalogModal onClose={() => {}} />);
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("export_catalog_cmd", { outZip: "C:\\Users\\me\\catalog.zip" })
+    );
+    await waitFor(() => expect(screen.getByText(/123/)).toBeInTheDocument());
+    expect(screen.getByText(/4\.[0-9]+.*MB/i)).toBeInTheDocument(); // loose — formatBytes varies
+  });
+
+  it("shows error from backend", async () => {
+    saveMock.mockResolvedValue("C:\\out.zip");
+    invokeMock.mockRejectedValueOnce(new Error("refusing to overwrite existing file: C:\\out.zip"));
+    render(<ExportCatalogModal onClose={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/refusing to overwrite/i)
+    );
+  });
+
+  it("opens containing folder when Open folder is clicked", async () => {
+    saveMock.mockResolvedValue("C:\\Users\\me\\catalog.zip");
+    invokeMock.mockResolvedValue({ zipPath: "C:\\Users\\me\\catalog.zip", entries: 5, bytes: 1024 });
+    openPathMock.mockResolvedValue(undefined);
+    render(<ExportCatalogModal onClose={() => {}} />);
+    const btn = await screen.findByRole("button", { name: /open folder/i });
+    await userEvent.click(btn);
+    expect(openPathMock).toHaveBeenCalledWith("C:\\Users\\me");
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/HelpModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/HelpModal.test.tsx
@@ -16,6 +16,13 @@ describe("HelpModal", () => {
     expect(screen.getByText("album:vacation")).toBeInTheDocument();
   });
 
+  it("shows camera, lens, and time filter examples", () => {
+    render(<HelpModal onClose={() => {}} />);
+    expect(screen.getByText("camera:Sony")).toBeInTheDocument();
+    expect(screen.getByText("lens:50mm")).toBeInTheDocument();
+    expect(screen.getByText("time:morning")).toBeInTheDocument();
+  });
+
   it("calls onClose when Close button clicked", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/sherlock/desktop/src/__tests__/components/ImageGrid.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/ImageGrid.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import ImageGrid from "../../components/Content/ImageGrid";
+import type { SearchItem } from "../../types";
+
+function makeItem(id: number, mtimeNs: number): SearchItem {
+  return {
+    id,
+    rootId: 1,
+    relPath: `photo_${id}.jpg`,
+    absPath: `/photos/photo_${id}.jpg`,
+    mediaType: "photo",
+    description: `Photo ${id}`,
+    confidence: 0.9,
+    mtimeNs,
+    sizeBytes: 1024,
+  };
+}
+
+// 3 items within 2s → burst
+const BASE_NS = 1_700_000_000_000_000_000;
+const BURST_ITEMS: SearchItem[] = [
+  makeItem(1, BASE_NS),
+  makeItem(2, BASE_NS + 500_000_000),   // +0.5s
+  makeItem(3, BASE_NS + 1_000_000_000), // +1s
+  makeItem(4, BASE_NS + 3_600_000_000_000), // +1h — separate non-burst item
+];
+
+const defaultGridProps = {
+  selectedIndices: new Set<number>(),
+  focusIndex: null,
+  gridRef: createRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>,
+  onTileClick: vi.fn(),
+  onTileDoubleClick: vi.fn(),
+  onTileContextMenu: vi.fn(),
+};
+
+describe("ImageGrid", () => {
+  it("renders all items without burst collapse", () => {
+    render(<ImageGrid items={BURST_ITEMS} {...defaultGridProps} />);
+    // Each filename appears twice (tile-filename + hover-overlay)
+    expect(screen.getAllByText("photo_1.jpg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("photo_2.jpg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("photo_3.jpg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("photo_4.jpg").length).toBeGreaterThan(0);
+  });
+
+  it("collapses burst members and shows badge when collapseBursts=true", () => {
+    render(<ImageGrid items={BURST_ITEMS} {...defaultGridProps} collapseBursts={true} />);
+    // Cover (id=1) is shown
+    expect(screen.getAllByText("photo_1.jpg").length).toBeGreaterThan(0);
+    // Burst members (id=2, id=3) are collapsed — not in DOM at all
+    expect(screen.queryAllByText("photo_2.jpg")).toHaveLength(0);
+    expect(screen.queryAllByText("photo_3.jpg")).toHaveLength(0);
+    // Non-burst item (id=4) is still shown
+    expect(screen.getAllByText("photo_4.jpg").length).toBeGreaterThan(0);
+    // Badge shows "+2"
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+
+  it("expands burst when badge is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ImageGrid items={BURST_ITEMS} {...defaultGridProps} collapseBursts={true} />);
+    const badge = screen.getByText("+2");
+    await user.click(badge);
+    // Now members should be visible (each appears twice in tile DOM)
+    expect(screen.getAllByText("photo_2.jpg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("photo_3.jpg").length).toBeGreaterThan(0);
+  });
+
+  it("does not show burst badge when collapseBursts is false (default)", () => {
+    render(<ImageGrid items={BURST_ITEMS} {...defaultGridProps} collapseBursts={false} />);
+    expect(screen.queryByText("+2")).not.toBeInTheDocument();
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/ImportCatalogModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/ImportCatalogModal.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ImportCatalogModal from "../../components/modals/ImportCatalogModal";
+
+const invokeMock = vi.fn();
+const openMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => openMock(...args),
+  save: vi.fn(),
+}));
+
+describe("ImportCatalogModal", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    openMock.mockReset();
+  });
+
+  it("renders the confirm step with Cancel and Choose file buttons", () => {
+    render(<ImportCatalogModal onClose={() => {}} />);
+    expect(screen.getByText(/importing will restore a catalog bundle/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /choose file/i })).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked on confirm step", async () => {
+    const onClose = vi.fn();
+    render(<ImportCatalogModal onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("stays on confirm step when user dismisses file picker", async () => {
+    openMock.mockResolvedValue(null);
+    render(<ImportCatalogModal onClose={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /choose file/i }));
+    // Returns to confirm step
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /choose file/i })).toBeInTheDocument()
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("picks a file, invokes import, and shows success UI", async () => {
+    openMock.mockResolvedValue("C:\\Users\\me\\catalog.zip");
+    invokeMock.mockResolvedValue({ entries: 77, bytes: 2048 });
+    render(<ImportCatalogModal onClose={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /choose file/i }));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("import_catalog_cmd", { bundle: "C:\\Users\\me\\catalog.zip" })
+    );
+    await waitFor(() => expect(screen.getByText(/77/)).toBeInTheDocument());
+    expect(screen.getByText(/restart recommended/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the overwrite-refused error with a hint", async () => {
+    openMock.mockResolvedValue("C:\\bundle.zip");
+    invokeMock.mockRejectedValueOnce(
+      new Error("refusing to overwrite existing catalog at C:\\cat\\db"),
+    );
+    render(<ImportCatalogModal onClose={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /choose file/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/refusing to overwrite existing catalog/i),
+    );
+    expect(screen.getByText(/export or move the existing catalog first/i)).toBeInTheDocument();
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/RemapRootModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/RemapRootModal.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RemapRootModal from "../../components/modals/RemapRootModal";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+const OLD_PATH = "D:\\Photos";
+const NEW_PATH = "E:\\Photos";
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  // React tracks the native value setter; overriding it ensures controlled
+  // inputs register the change even when the string contains backslashes
+  // (which can be mishandled by plain fireEvent.change in some scenarios).
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  nativeSetter?.call(input, value);
+  fireEvent.input(input);
+}
+
+describe("RemapRootModal", () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it("submits old and new paths to remap_root_cmd and surfaces the count", async () => {
+    invokeMock.mockResolvedValue({ rootsUpdated: 1, filesUpdated: 42, scanJobsUpdated: 1 });
+    const onRemapped = vi.fn();
+    render(<RemapRootModal oldPath={OLD_PATH} onClose={() => {}} onRemapped={onRemapped} />);
+
+    const input = screen.getByLabelText(/new path/i) as HTMLInputElement;
+    setInputValue(input, NEW_PATH);
+    expect(input.value).toBe(NEW_PATH);
+    fireEvent.click(screen.getByRole("button", { name: /remap/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("remap_root_cmd", {
+        oldPath: OLD_PATH,
+        newPath: NEW_PATH,
+      })
+    );
+    expect(onRemapped).toHaveBeenCalledWith({ rootsUpdated: 1, filesUpdated: 42, scanJobsUpdated: 1 });
+    await waitFor(() => expect(screen.getByText(/42 files updated/i)).toBeInTheDocument());
+  });
+
+  it("shows backend error and does NOT call onRemapped", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("no such root: D:\\Photos"));
+    const onRemapped = vi.fn();
+    render(<RemapRootModal oldPath={OLD_PATH} onClose={() => {}} onRemapped={onRemapped} />);
+
+    const input = screen.getByLabelText(/new path/i) as HTMLInputElement;
+    setInputValue(input, "Z:\\x");
+    expect(input.value).toBe("Z:\\x");
+    fireEvent.click(screen.getByRole("button", { name: /remap/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/no such root/i));
+    expect(onRemapped).not.toHaveBeenCalled();
+  });
+
+  it("disables remap button when new path equals old path", () => {
+    render(<RemapRootModal oldPath={OLD_PATH} onClose={() => {}} onRemapped={() => {}} />);
+    const btn = screen.getByRole("button", { name: /remap/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/RootCard.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/RootCard.test.tsx
@@ -7,7 +7,7 @@ import { mockRoot as sampleRoot, mockRunningScan } from "../fixtures";
 describe("RootCard", () => {
   it("renders root name and file count", () => {
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     expect(screen.getByText("photos")).toBeInTheDocument();
     expect(screen.getByText("42 files")).toBeInTheDocument();
@@ -15,7 +15,7 @@ describe("RootCard", () => {
 
   it("applies selected class when selected", () => {
     const { container } = render(
-      <RootCard root={sampleRoot} isSelected scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     expect(container.querySelector(".root-card.selected")).not.toBeNull();
   });
@@ -23,7 +23,7 @@ describe("RootCard", () => {
   it("calls onSelect when clicked", async () => {
     const onSelect = vi.fn();
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={onSelect} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={onSelect} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     await userEvent.click(screen.getByText("photos"));
     expect(onSelect).toHaveBeenCalled();
@@ -32,7 +32,7 @@ describe("RootCard", () => {
   it("calls onDelete when delete button clicked", async () => {
     const onDelete = vi.fn();
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={onDelete} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={onDelete} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     await userEvent.click(screen.getByLabelText("Remove photos"));
     expect(onDelete).toHaveBeenCalled();
@@ -40,14 +40,14 @@ describe("RootCard", () => {
 
   it("hides delete button in readOnly mode", () => {
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     expect(screen.queryByLabelText("Remove photos")).not.toBeInTheDocument();
   });
 
   it("shows scan progress with stats when scan is running (classifying phase)", () => {
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onCancelScan={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onCancelScan={vi.fn()} />
     );
     expect(screen.getByText("Classifying 50/100")).toBeInTheDocument();
   });
@@ -55,7 +55,7 @@ describe("RootCard", () => {
   it("shows scan progress with stats when scan is thumbnailing", () => {
     const thumbnailingScan = { ...mockRunningScan, phase: "thumbnailing" as const };
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={thumbnailingScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onCancelScan={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={thumbnailingScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onCancelScan={vi.fn()} />
     );
     expect(screen.getByText("Thumbnailing 50/100")).toBeInTheDocument();
     expect(screen.getByText(/\+10 new, 5 mod, 2 moved/)).toBeInTheDocument();
@@ -64,14 +64,14 @@ describe("RootCard", () => {
   it("shows pause button for running scan", () => {
     const onCancelScan = vi.fn();
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onCancelScan={onCancelScan} />
+      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onCancelScan={onCancelScan} />
     );
     expect(screen.getByText("Pause")).toBeInTheDocument();
   });
 
   it("hides pause button in readOnly mode", () => {
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onCancelScan={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={mockRunningScan} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onCancelScan={vi.fn()} />
     );
     expect(screen.queryByText("Pause")).not.toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe("RootCard", () => {
     const interruptedScan = { ...mockRunningScan, status: "interrupted" as const };
     const onResumeScan = vi.fn();
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={interruptedScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onResumeScan={onResumeScan} />
+      <RootCard root={sampleRoot} isSelected={false} scan={interruptedScan} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onResumeScan={onResumeScan} />
     );
     expect(screen.getByText("Scan interrupted")).toBeInTheDocument();
     expect(screen.getByText("Resume")).toBeInTheDocument();
@@ -89,14 +89,14 @@ describe("RootCard", () => {
   it("hides resume button in readOnly mode", () => {
     const interruptedScan = { ...mockRunningScan, status: "interrupted" as const };
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={interruptedScan} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onResumeScan={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={interruptedScan} readOnly onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} onResumeScan={vi.fn()} />
     );
     expect(screen.queryByText("Resume")).not.toBeInTheDocument();
   });
 
   it("shows Refresh Metadata in context menu", async () => {
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={vi.fn()} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     const card = screen.getByText("photos").closest(".root-card")!;
     await userEvent.pointer({ keys: "[MouseRight]", target: card });
@@ -106,7 +106,7 @@ describe("RootCard", () => {
   it("calls onRefresh from context menu", async () => {
     const onRefresh = vi.fn();
     render(
-      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={onRefresh} onCopyPath={vi.fn()} />
+      <RootCard root={sampleRoot} isSelected={false} scan={undefined} readOnly={false} onSelect={vi.fn()} onDelete={vi.fn()} onRescan={vi.fn()} onRefresh={onRefresh} onCopyPath={vi.fn()} onRemap={vi.fn()} />
     );
     const card = screen.getByText("photos").closest(".root-card")!;
     await userEvent.pointer({ keys: "[MouseRight]", target: card });

--- a/sherlock/desktop/src/__tests__/components/Sidebar.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/Sidebar.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
   onRescanRoot: vi.fn(),
   onRefreshRoot: vi.fn(),
   onCopyRootPath: vi.fn(),
+  onRemapRoot: vi.fn(),
   onDetectFaces: vi.fn(),
   onCancelFaceDetect: vi.fn(),
   onPickAndScan: vi.fn(),

--- a/sherlock/desktop/src/__tests__/components/SimilarResultsModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/SimilarResultsModal.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SimilarResultsModal from "../../components/modals/SimilarResultsModal";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...args: unknown[]) => invokeMock(...args) }));
+
+describe("SimilarResultsModal", () => {
+  beforeEach(() => invokeMock.mockReset());
+
+  it("invokes find_similar_cmd on mount and renders the results", async () => {
+    invokeMock.mockResolvedValue([
+      { fileId: 2, rootId: 1, relPath: "b.jpg", absPath: "D:/b.jpg", filename: "b.jpg",
+        mediaType: "photo", description: "sunset", thumbPath: null, score: 0.97 },
+      { fileId: 3, rootId: 1, relPath: "c.jpg", absPath: "D:/c.jpg", filename: "c.jpg",
+        mediaType: "photo", description: "beach", thumbPath: null, score: 0.82 },
+    ]);
+    render(<SimilarResultsModal sourceFileId={1} sourceLabel="a.jpg" onClose={() => {}} />);
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("find_similar_cmd", {
+        fileId: 1, limit: 20, minScore: 0.5,
+      })
+    );
+    await waitFor(() => expect(screen.getByText("b.jpg")).toBeInTheDocument());
+    expect(screen.getByText("c.jpg")).toBeInTheDocument();
+    expect(screen.getByText(/97%/)).toBeInTheDocument();
+    expect(screen.getByText(/82%/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no matches", async () => {
+    invokeMock.mockResolvedValue([]);
+    render(<SimilarResultsModal sourceFileId={1} sourceLabel="a.jpg" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/no similar/i)).toBeInTheDocument());
+  });
+
+  it("surfaces backend errors", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("no such file: 9999"));
+    render(<SimilarResultsModal sourceFileId={9999} sourceLabel="missing" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/no such file/i));
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/TagRulesModal.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/TagRulesModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import TagRulesModal from "../../components/modals/TagRulesModal";
+import type { TagRule } from "../../types";
+
+const mockedInvoke = vi.mocked(invoke);
+
+const mockRule: TagRule = {
+  id: 1,
+  pattern: "^Screenshots/",
+  tag: "screenshot",
+  enabled: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedInvoke.mockImplementation((cmd) => {
+    if (cmd === "list_tag_rules") return Promise.resolve([]);
+    return Promise.resolve(undefined);
+  });
+});
+
+describe("TagRulesModal", () => {
+  it("renders empty state when no rules", async () => {
+    render(<TagRulesModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+    expect(screen.getByText("No rules yet")).toBeDefined();
+  });
+
+  it("renders existing rules from the backend", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "list_tag_rules") return Promise.resolve([mockRule]);
+      return Promise.resolve(undefined);
+    });
+    render(<TagRulesModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+    expect(screen.getByText("^Screenshots/")).toBeDefined();
+    expect(screen.getByText("screenshot")).toBeDefined();
+  });
+
+  it("adds a new rule when Add is clicked", async () => {
+    const newRule: TagRule = { id: 2, pattern: "^Videos/", tag: "video", enabled: true };
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "list_tag_rules") return Promise.resolve([]);
+      if (cmd === "create_tag_rule") return Promise.resolve(newRule);
+      return Promise.resolve(undefined);
+    });
+
+    render(<TagRulesModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    fireEvent.change(screen.getByPlaceholderText(/Regex pattern/), {
+      target: { value: "^Videos/" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Tag"), {
+      target: { value: "video" },
+    });
+    fireEvent.click(screen.getByText("Add"));
+
+    await waitFor(() =>
+      expect(mockedInvoke).toHaveBeenCalledWith("create_tag_rule", {
+        pattern: "^Videos/",
+        tag: "video",
+      })
+    );
+    await waitFor(() => expect(screen.getByText("^Videos/")).toBeDefined());
+  });
+
+  it("shows error for invalid regex", async () => {
+    render(<TagRulesModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    fireEvent.change(screen.getByPlaceholderText(/Regex pattern/), {
+      target: { value: "[invalid(" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Tag"), {
+      target: { value: "test" },
+    });
+    fireEvent.click(screen.getByText("Add"));
+
+    expect(screen.getByText("Invalid regex pattern")).toBeDefined();
+  });
+
+  it("deletes a rule when ✕ is clicked", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "list_tag_rules") return Promise.resolve([mockRule]);
+      if (cmd === "delete_tag_rule") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+
+    render(<TagRulesModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText("^Screenshots/")).toBeDefined());
+
+    fireEvent.click(screen.getByLabelText("Delete rule"));
+
+    await waitFor(() =>
+      expect(mockedInvoke).toHaveBeenCalledWith("delete_tag_rule", { ruleId: 1 })
+    );
+    await waitFor(() => expect(screen.queryByText("^Screenshots/")).toBeNull());
+  });
+
+  it("calls onClose when Close is clicked", async () => {
+    const onClose = vi.fn();
+    render(<TagRulesModal onClose={onClose} />);
+    await waitFor(() => expect(screen.queryByText("Loading…")).toBeNull());
+
+    fireEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/TimelineHeatmap.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/TimelineHeatmap.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TimelineHeatmap from "../../components/Content/TimelineHeatmap";
+
+vi.mock("../../api", () => ({
+  listTimelineBuckets: vi.fn(),
+}));
+
+import { listTimelineBuckets } from "../../api";
+const mockList = listTimelineBuckets as ReturnType<typeof vi.fn>;
+
+describe("TimelineHeatmap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state initially then renders rows", async () => {
+    mockList.mockResolvedValue([
+      { bucket: "2023-01", count: 5 },
+      { bucket: "2023-06", count: 12 },
+    ]);
+    render(<TimelineHeatmap onQueryChange={() => {}} />);
+    // After resolution, both months visible
+    await waitFor(() => {
+      expect(screen.getByTitle(/2023-01/)).toBeInTheDocument();
+      expect(screen.getByTitle(/2023-06/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows month labels in short format", async () => {
+    mockList.mockResolvedValue([{ bucket: "2023-06", count: 3 }]);
+    render(<TimelineHeatmap onQueryChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Jun '23/)).toBeInTheDocument();
+    });
+  });
+
+  it("calls onQueryChange with date range when month clicked", async () => {
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    mockList.mockResolvedValue([{ bucket: "2023-06", count: 8 }]);
+    render(<TimelineHeatmap onQueryChange={onQueryChange} />);
+    await waitFor(() => screen.getByTitle(/2023-06/));
+    await user.click(screen.getByTitle(/2023-06/));
+    expect(onQueryChange).toHaveBeenCalledWith("2023-06-01 2023-06-30");
+  });
+
+  it("deselects (clears query) when active month clicked again", async () => {
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    mockList.mockResolvedValue([{ bucket: "2023-06", count: 8 }]);
+    render(<TimelineHeatmap onQueryChange={onQueryChange} />);
+    await waitFor(() => screen.getByTitle(/2023-06/));
+    const btn = screen.getByTitle(/2023-06/);
+    await user.click(btn);
+    await user.click(btn);
+    // Second click should pass empty string
+    const calls = onQueryChange.mock.calls;
+    expect(calls.at(-1)?.[0]).toBe("");
+  });
+
+  it("shows 'No photos yet' when list is empty", async () => {
+    mockList.mockResolvedValue([]);
+    render(<TimelineHeatmap onQueryChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText("No photos yet")).toBeInTheDocument();
+    });
+  });
+});

--- a/sherlock/desktop/src/__tests__/components/Toolbar.test.tsx
+++ b/sherlock/desktop/src/__tests__/components/Toolbar.test.tsx
@@ -111,4 +111,39 @@ describe("Toolbar", () => {
     );
     expect(screen.queryByLabelText("Sort direction")).not.toBeInTheDocument();
   });
+
+  it("renders blur toggle button with inactive state by default", () => {
+    render(
+      <Toolbar query="" onQueryChange={() => {}} selectedMediaType="" onMediaTypeChange={() => {}} mediaTypeOptions={mediaTypes} {...defaultSortProps} />
+    );
+    const btn = screen.getByLabelText(/Blur:/);
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    expect(btn).toHaveTextContent("~");
+  });
+
+  it("blur toggle cycles none → sharp → blurry → none on repeated clicks", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Toolbar query="" onQueryChange={onChange} selectedMediaType="" onMediaTypeChange={() => {}} mediaTypeOptions={mediaTypes} {...defaultSortProps} />
+    );
+    const btn = screen.getByLabelText(/Blur:/);
+    // none → sharp: appends blur:false
+    await user.click(btn);
+    expect(onChange).toHaveBeenLastCalledWith("blur:false");
+    // Simulate the query prop being updated to "blur:false"
+  });
+
+  it("blur toggle removes blur token when cycling back to none", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Toolbar query="blur:false" onQueryChange={onChange} selectedMediaType="" onMediaTypeChange={() => {}} mediaTypeOptions={mediaTypes} {...defaultSortProps} />
+    );
+    const btn = screen.getByLabelText(/Blur:/);
+    // sharp → blurry: replaces blur:false with blur:true
+    await user.click(btn);
+    expect(onChange).toHaveBeenLastCalledWith("blur:true");
+  });
 });

--- a/sherlock/desktop/src/__tests__/setup.ts
+++ b/sherlock/desktop/src/__tests__/setup.ts
@@ -24,9 +24,11 @@ vi.mock("@tauri-apps/api/window", () => ({
 // Mock @tauri-apps/plugin-dialog
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
+  save: vi.fn(),
 }));
 
 // Mock @tauri-apps/plugin-opener
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
+  openPath: vi.fn(),
 }));

--- a/sherlock/desktop/src/api.ts
+++ b/sherlock/desktop/src/api.ts
@@ -9,6 +9,7 @@ import type {
   FaceInfo,
   FileMetadata,
   FileProperties,
+  FilterOption,
   HealthStatus,
   PdfPassword,
   PersonInfo,
@@ -24,8 +25,10 @@ import type {
   SetupStatus,
   SmartFolder,
   SubdirEntry,
+  Suggestion,
   SearchRequest,
   SearchResponse,
+  TimelineBucket,
   VenvProvisionStatus,
 } from "./types";
 
@@ -270,4 +273,22 @@ export async function reassignFacesToPerson(faceIds: number[], targetPersonId: n
 
 export async function setRepresentativeFace(personId: number, faceId: number): Promise<void> {
   return invoke<void>("set_representative_face", { personId, faceId });
+}
+
+// ── Phase 1/2: EXIF filters, autocomplete, timeline ─────────────────
+
+export async function listCameras(): Promise<FilterOption[]> {
+  return invoke<FilterOption[]>("list_cameras_cmd");
+}
+
+export async function listLenses(): Promise<FilterOption[]> {
+  return invoke<FilterOption[]>("list_lenses_cmd");
+}
+
+export async function suggestTags(prefix: string, limit = 8): Promise<Suggestion[]> {
+  return invoke<Suggestion[]>("suggest_cmd", { prefix, limit });
+}
+
+export async function listTimelineBuckets(): Promise<TimelineBucket[]> {
+  return invoke<TimelineBucket[]>("list_timeline_buckets_cmd");
 }

--- a/sherlock/desktop/src/api.ts
+++ b/sherlock/desktop/src/api.ts
@@ -1,10 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   Album,
+  Burst,
   ClusterResult,
   DbStats,
+  DedupStrategy,
   DeleteFilesResult,
   DuplicatesResponse,
+  EventSummary,
   FaceDetectProgress,
   FaceInfo,
   FileMetadata,
@@ -29,6 +32,7 @@ import type {
   SearchRequest,
   SearchResponse,
   TimelineBucket,
+  TripSummary,
   VenvProvisionStatus,
 } from "./types";
 
@@ -291,4 +295,42 @@ export async function suggestTags(prefix: string, limit = 8): Promise<Suggestion
 
 export async function listTimelineBuckets(): Promise<TimelineBucket[]> {
   return invoke<TimelineBucket[]>("list_timeline_buckets_cmd");
+}
+
+// ── Auto-clustering ──────────────────────────────────────────────────
+
+export async function recomputeEvents(): Promise<EventSummary[]> {
+  return invoke<EventSummary[]>("recompute_events_cmd");
+}
+
+export async function listEvents(): Promise<EventSummary[]> {
+  return invoke<EventSummary[]>("list_events_cmd");
+}
+
+export async function detectTrips(): Promise<TripSummary[]> {
+  return invoke<TripSummary[]>("detect_trips_cmd");
+}
+
+export async function listTrips(): Promise<TripSummary[]> {
+  return invoke<TripSummary[]>("list_trips_cmd");
+}
+
+export async function findBursts(): Promise<Burst[]> {
+  return invoke<Burst[]>("find_bursts_cmd");
+}
+
+export async function generateYearReview(year: number): Promise<number> {
+  return invoke<number>("generate_year_review_cmd", { year });
+}
+
+export async function setDedupPolicy(strategy: DedupStrategy): Promise<void> {
+  return invoke<void>("set_dedup_policy_cmd", { strategy });
+}
+
+export async function getDedupPolicy(): Promise<DedupStrategy | null> {
+  return invoke<DedupStrategy | null>("get_dedup_policy_cmd");
+}
+
+export async function applyDedupPolicy(): Promise<number> {
+  return invoke<number>("apply_dedup_policy_cmd");
 }

--- a/sherlock/desktop/src/api.ts
+++ b/sherlock/desktop/src/api.ts
@@ -31,6 +31,7 @@ import type {
   Suggestion,
   SearchRequest,
   SearchResponse,
+  SavedSearch,
   TagRule,
   TimelineBucket,
   TripSummary,
@@ -194,6 +195,24 @@ export async function deleteTagRule(ruleId: number): Promise<void> {
 
 export async function setTagRuleEnabled(ruleId: number, enabled: boolean): Promise<void> {
   return invoke<void>("set_tag_rule_enabled", { ruleId, enabled });
+}
+
+// ── Saved Searches ──────────────────────────────────────────────────
+
+export async function listSavedSearches(): Promise<SavedSearch[]> {
+  return invoke<SavedSearch[]>("list_saved_searches");
+}
+
+export async function createSavedSearch(name: string, query: string): Promise<SavedSearch> {
+  return invoke<SavedSearch>("create_saved_search", { name, query });
+}
+
+export async function deleteSavedSearch(searchId: number): Promise<void> {
+  return invoke<void>("delete_saved_search", { searchId });
+}
+
+export async function setSavedSearchNotify(searchId: number, notify: boolean): Promise<void> {
+  return invoke<void>("set_saved_search_notify", { searchId, notify });
 }
 
 // ── Duplicates ──────────────────────────────────────────────────────

--- a/sherlock/desktop/src/api.ts
+++ b/sherlock/desktop/src/api.ts
@@ -31,6 +31,7 @@ import type {
   Suggestion,
   SearchRequest,
   SearchResponse,
+  TagRule,
   TimelineBucket,
   TripSummary,
   VenvProvisionStatus,
@@ -155,6 +156,10 @@ export async function addFilesToAlbum(albumId: number, fileIds: number[]): Promi
   return invoke<number>("add_files_to_album", { albumId, fileIds });
 }
 
+export async function updateAlbumTag(albumId: number, tag: string): Promise<void> {
+  return invoke<void>("update_album_tag", { albumId, tag });
+}
+
 // ── Smart Folders ───────────────────────────────────────────────────
 
 export async function createSmartFolder(name: string, query: string): Promise<SmartFolder> {
@@ -167,6 +172,28 @@ export async function deleteSmartFolder(folderId: number): Promise<void> {
 
 export async function listSmartFolders(): Promise<SmartFolder[]> {
   return invoke<SmartFolder[]>("list_smart_folders");
+}
+
+export async function createFaceSmartAlbum(personName: string): Promise<SmartFolder> {
+  return invoke<SmartFolder>("create_face_smart_album", { personName });
+}
+
+// ── Tag Rules ───────────────────────────────────────────────────────
+
+export async function listTagRules(): Promise<TagRule[]> {
+  return invoke<TagRule[]>("list_tag_rules");
+}
+
+export async function createTagRule(pattern: string, tag: string): Promise<TagRule> {
+  return invoke<TagRule>("create_tag_rule", { pattern, tag });
+}
+
+export async function deleteTagRule(ruleId: number): Promise<void> {
+  return invoke<void>("delete_tag_rule", { ruleId });
+}
+
+export async function setTagRuleEnabled(ruleId: number, enabled: boolean): Promise<void> {
+  return invoke<void>("set_tag_rule_enabled", { ruleId, enabled });
 }
 
 // ── Duplicates ──────────────────────────────────────────────────────

--- a/sherlock/desktop/src/components/Content/Content.css
+++ b/sherlock/desktop/src/components/Content/Content.css
@@ -116,6 +116,31 @@
   color: var(--text-primary);
 }
 
+/* ── Blur toggle button ──────────────────────────────────── */
+.toolbar-blur-toggle {
+  padding: 4px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  flex-shrink: 0;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+.toolbar-blur-toggle:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.toolbar-blur-active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
 /* ── Content body ─────────────────────────────────────────── */
 .content-body {
   flex: 1;
@@ -221,6 +246,36 @@
   pointer-events: none;
   line-height: 1.2;
   font-weight: 600;
+}
+
+/* Burst count badge — shown on burst cover photo */
+.image-tile-wrapper {
+  position: relative;
+}
+
+.burst-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.3);
+  cursor: pointer;
+  z-index: 2;
+  line-height: 1.4;
+  transition: background 0.1s;
+}
+
+.burst-badge:hover {
+  background: rgba(0, 100, 220, 0.85);
+}
+
+.burst-badge-expanded {
+  background: rgba(0, 100, 220, 0.72);
 }
 
 /* Filename bar — always visible at bottom */

--- a/sherlock/desktop/src/components/Content/Content.tsx
+++ b/sherlock/desktop/src/components/Content/Content.tsx
@@ -73,6 +73,7 @@ export default function Content({
           onTileClick={onTileClick}
           onTileDoubleClick={onTileDoubleClick}
           onTileContextMenu={onTileContextMenu}
+          collapseBursts={sortBy === "dateModified"}
         />
 
         {canLoadMore && (

--- a/sherlock/desktop/src/components/Content/Content.tsx
+++ b/sherlock/desktop/src/components/Content/Content.tsx
@@ -17,6 +17,7 @@ type ContentProps = {
   onSortOrderChange: (v: SortOrder) => void;
   hasTextQuery: boolean;
   onSaveSmartFolder?: () => void;
+  onSaveSearch?: () => void;
   items: SearchItem[];
   total: number;
   loading: boolean;
@@ -36,6 +37,7 @@ type ContentProps = {
 export default function Content({
   query, onQueryChange, selectedMediaType, onMediaTypeChange, mediaTypeOptions,
   sortBy, onSortByChange, sortOrder, onSortOrderChange, hasTextQuery, onSaveSmartFolder,
+  onSaveSearch,
   items, total, loading, loadingMore, canLoadMore, isScanning, selectedRootName,
   selectedIndices, focusIndex, gridRef, sentinelRef, onTileClick, onTileDoubleClick,
   onTileContextMenu,
@@ -54,6 +56,7 @@ export default function Content({
         onSortOrderChange={onSortOrderChange}
         hasTextQuery={hasTextQuery}
         onSaveSmartFolder={onSaveSmartFolder}
+        onSaveSearch={onSaveSearch}
       />
 
       <div className="content-body">

--- a/sherlock/desktop/src/components/Content/ContextMenu.tsx
+++ b/sherlock/desktop/src/components/Content/ContextMenu.tsx
@@ -16,6 +16,7 @@ type Props = {
   onRename: () => void;
   onEditMetadata: () => void;
   onProperties: () => void;
+  onFindSimilar: () => void;
   onDelete: () => void;
   onAddToAlbum: (albumId: number) => void;
   onCreateAlbumFromSelection: () => void;
@@ -25,7 +26,7 @@ type Props = {
 export default function ContextMenu({
   x, y, selectedCount, albums, description, extractedText, confidence,
   onCopyPath, onCopyDescription, onCopyOcrText, onRename, onEditMetadata, onProperties,
-  onDelete, onAddToAlbum, onCreateAlbumFromSelection, onClose,
+  onFindSimilar, onDelete, onAddToAlbum, onCreateAlbumFromSelection, onClose,
 }: Props) {
   const isUnclassified = confidence !== null && confidence === 0;
   const menuRef = useRef<HTMLDivElement>(null);
@@ -111,6 +112,12 @@ export default function ContextMenu({
       {selectedCount === 1 && (
         <button className="context-menu-item" role="menuitem" onClick={onProperties}>
           <span>Properties</span>
+        </button>
+      )}
+
+      {selectedCount === 1 && (
+        <button className="context-menu-item" role="menuitem" onClick={onFindSimilar}>
+          <span>Find similar</span>
         </button>
       )}
 

--- a/sherlock/desktop/src/components/Content/DuplicatesView.css
+++ b/sherlock/desktop/src/components/Content/DuplicatesView.css
@@ -16,6 +16,24 @@
   opacity: 0.4;
 }
 
+/* ── Dedup policy row ────────────────────────────────────── */
+.dedup-policy-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.dedup-policy-row select {
+  width: 140px;
+  font-size: var(--font-size-sm);
+}
+
+.dedup-policy-row button {
+  white-space: nowrap;
+  font-size: var(--font-size-sm);
+}
+
 /* ── Group card ──────────────────────────────────────────── */
 .dup-group {
   border: 1px solid var(--border-primary);

--- a/sherlock/desktop/src/components/Content/DuplicatesView.tsx
+++ b/sherlock/desktop/src/components/Content/DuplicatesView.tsx
@@ -1,5 +1,6 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import type { DuplicatesResponse, DuplicateFile, DuplicateGroup } from "../../types";
+import { useState } from "react";
+import type { DuplicatesResponse, DuplicateFile, DuplicateGroup, DedupStrategy } from "../../types";
 import { fileName } from "../../utils/format";
 import { formatBytes } from "../../utils/format";
 import "./shared-tool-view.css";
@@ -20,6 +21,7 @@ type Props = {
   onBack: () => void;
   onSelectGroupDuplicates: (group: DuplicateGroup) => void;
   onPreviewGroup: (group: DuplicateGroup) => void;
+  onApplyDedupPolicy?: (strategy: DedupStrategy) => Promise<void>;
 };
 
 function formatDate(mtimeNs: number): string {
@@ -31,8 +33,21 @@ export default function DuplicatesView({
   data, loading, selected,
   nearEnabled, nearThreshold, onNearEnabledChange, onNearThresholdChange,
   onToggleFile, onSelectAllDuplicates, onDeselectAll, onDeleteSelected,
-  onBack, onSelectGroupDuplicates, onPreviewGroup,
+  onBack, onSelectGroupDuplicates, onPreviewGroup, onApplyDedupPolicy,
 }: Props) {
+  const [dedupStrategy, setDedupStrategy] = useState<DedupStrategy>("keepLargest");
+  const [applyingPolicy, setApplyingPolicy] = useState(false);
+
+  async function handleApplyPolicy() {
+    if (!onApplyDedupPolicy) return;
+    setApplyingPolicy(true);
+    try {
+      await onApplyDedupPolicy(dedupStrategy);
+    } finally {
+      setApplyingPolicy(false);
+    }
+  }
+
   return (
     <div className="tool-view">
       <div className="tool-toolbar">
@@ -59,6 +74,28 @@ export default function DuplicatesView({
               onChange={(e) => onNearThresholdChange(Number(e.target.value) / 100)}
             />
             <span className="near-threshold-label">{Math.round(nearThreshold * 100)}%</span>
+          </div>
+        )}
+        {onApplyDedupPolicy && (
+          <div className="dedup-policy-row">
+            <select
+              value={dedupStrategy}
+              onChange={(e) => setDedupStrategy(e.target.value as DedupStrategy)}
+              aria-label="Dedup strategy"
+              title="Auto-select which file to keep in each duplicate group"
+            >
+              <option value="keepLargest">Keep Largest</option>
+              <option value="keepOldest">Keep Oldest</option>
+              <option value="keepInAlbum">Keep In Album</option>
+            </select>
+            <button
+              type="button"
+              onClick={handleApplyPolicy}
+              disabled={applyingPolicy || data.totalDuplicateFiles === 0}
+              title="Auto-select duplicates to delete based on policy"
+            >
+              {applyingPolicy ? "Applying…" : "Apply Policy"}
+            </button>
           </div>
         )}
         {selected.size > 0 ? (

--- a/sherlock/desktop/src/components/Content/FacesView.tsx
+++ b/sherlock/desktop/src/components/Content/FacesView.tsx
@@ -23,6 +23,7 @@ type Props = {
   onPreviewFile: (fileIds: number[]) => void;
   onNotice: (msg: string) => void;
   onError: (msg: string) => void;
+  onCreateFaceSmartAlbum?: (personName: string) => void;
 };
 
 type ContextMenuState = {
@@ -36,7 +37,7 @@ type DetailContextMenuState = {
   y: number;
 } | null;
 
-export default function FacesView({ onBack, onSelectPerson, onPreviewFile, onNotice, onError }: Props) {
+export default function FacesView({ onBack, onSelectPerson, onPreviewFile, onNotice, onError, onCreateFaceSmartAlbum }: Props) {
   const [persons, setPersons] = useState<PersonInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -458,6 +459,18 @@ export default function FacesView({ onBack, onSelectPerson, onPreviewFile, onNot
         >
           Shuffle
         </button>
+        {onCreateFaceSmartAlbum && (
+          <button
+            type="button"
+            className="context-menu-item"
+            onClick={() => {
+              setContextMenuState(null);
+              onCreateFaceSmartAlbum(contextMenu.person.name);
+            }}
+          >
+            Create Smart Album
+          </button>
+        )}
       </div>
     );
   }

--- a/sherlock/desktop/src/components/Content/ImageGrid.tsx
+++ b/sherlock/desktop/src/components/Content/ImageGrid.tsx
@@ -1,6 +1,37 @@
+import { useMemo, useState } from "react";
 import type { RefObject } from "react";
 import type { SearchItem } from "../../types";
 import ImageTile from "./ImageTile";
+
+const BURST_GAP_NS = 2_000_000_000; // 2 seconds in nanoseconds
+
+/**
+ * Detect bursts from a date-sorted list of items.
+ * Returns a map of { coverId → memberIds[] } for bursts of ≥3 consecutive items
+ * with ≤2s mtime gap.
+ */
+function computeBurstGroups(items: SearchItem[]): Map<number, number[]> {
+  const groups = new Map<number, number[]>();
+  let i = 0;
+  while (i < items.length) {
+    let j = i + 1;
+    while (
+      j < items.length &&
+      items[j].mtimeNs - items[j - 1].mtimeNs <= BURST_GAP_NS
+    ) {
+      j++;
+    }
+    if (j - i >= 3) {
+      const coverId = items[i].id;
+      const memberIds = items.slice(i + 1, j).map((x) => x.id);
+      groups.set(coverId, memberIds);
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return groups;
+}
 
 type ImageGridProps = {
   items: SearchItem[];
@@ -10,25 +41,75 @@ type ImageGridProps = {
   onTileClick: (idx: number, e: React.MouseEvent) => void;
   onTileDoubleClick: (idx: number) => void;
   onTileContextMenu: (idx: number, e: React.MouseEvent) => void;
+  /** When true, consecutive items within 2s are collapsed into a burst group */
+  collapseBursts?: boolean;
 };
 
 export default function ImageGrid({
-  items, selectedIndices, focusIndex, gridRef, onTileClick, onTileDoubleClick, onTileContextMenu,
+  items, selectedIndices, focusIndex, gridRef,
+  onTileClick, onTileDoubleClick, onTileContextMenu,
+  collapseBursts = false,
 }: ImageGridProps) {
+  const [expandedBursts, setExpandedBursts] = useState<Set<number>>(new Set());
+
+  const burstGroups = useMemo(
+    () => (collapseBursts ? computeBurstGroups(items) : new Map<number, number[]>()),
+    [items, collapseBursts]
+  );
+
+  // Build set of IDs that are hidden (non-cover burst members when collapsed)
+  const hiddenIds = useMemo(() => {
+    const hidden = new Set<number>();
+    for (const [coverId, memberIds] of burstGroups) {
+      if (!expandedBursts.has(coverId)) {
+        for (const id of memberIds) hidden.add(id);
+      }
+    }
+    return hidden;
+  }, [burstGroups, expandedBursts]);
+
+  function toggleBurst(coverId: number) {
+    setExpandedBursts((prev) => {
+      const next = new Set(prev);
+      if (next.has(coverId)) next.delete(coverId);
+      else next.add(coverId);
+      return next;
+    });
+  }
+
   return (
     <div className="grid" role="list" ref={gridRef}>
-      {items.map((item, idx) => (
-        <ImageTile
-          key={item.id}
-          item={item}
-          index={idx}
-          isSelected={selectedIndices.has(idx)}
-          isFocused={focusIndex === idx}
-          onClick={onTileClick}
-          onDoubleClick={onTileDoubleClick}
-          onContextMenu={onTileContextMenu}
-        />
-      ))}
+      {items.map((item, idx) => {
+        if (hiddenIds.has(item.id)) return null;
+
+        const burstMembers = burstGroups.get(item.id);
+        const burstCount = burstMembers?.length ?? 0;
+        const isCollapsed = burstCount > 0 && !expandedBursts.has(item.id);
+
+        return (
+          <div key={item.id} className="image-tile-wrapper" style={{ position: "relative" }}>
+            <ImageTile
+              item={item}
+              index={idx}
+              isSelected={selectedIndices.has(idx)}
+              isFocused={focusIndex === idx}
+              onClick={onTileClick}
+              onDoubleClick={onTileDoubleClick}
+              onContextMenu={onTileContextMenu}
+            />
+            {burstCount > 0 && (
+              <button
+                className={`burst-badge${isCollapsed ? " burst-badge-collapsed" : " burst-badge-expanded"}`}
+                title={isCollapsed ? `Burst: +${burstCount} more — click to expand` : "Collapse burst"}
+                onClick={(e) => { e.stopPropagation(); toggleBurst(item.id); }}
+                aria-label={isCollapsed ? `Show ${burstCount} more burst photos` : "Collapse burst photos"}
+              >
+                {isCollapsed ? `+${burstCount}` : "−"}
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/sherlock/desktop/src/components/Content/TimelineHeatmap.css
+++ b/sherlock/desktop/src/components/Content/TimelineHeatmap.css
@@ -1,0 +1,77 @@
+/* ── TimelineHeatmap ──────────────────────────────────────────── */
+.timeline-heatmap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0;
+  overflow-y: auto;
+  max-height: 300px;
+}
+
+.timeline-heatmap__empty {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 8px 0;
+  margin: 0;
+}
+
+.timeline-heatmap__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  padding: 2px 4px;
+  text-align: left;
+  width: 100%;
+  font-size: 0.68rem;
+  color: var(--text-secondary);
+}
+
+.timeline-heatmap__row:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.timeline-heatmap__row--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.timeline-heatmap__label {
+  flex: 0 0 48px;
+  font-family: monospace;
+  font-size: 0.65rem;
+  text-align: right;
+}
+
+.timeline-heatmap__bar-wrap {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-base);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.timeline-heatmap__bar {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  opacity: 0.6;
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+.timeline-heatmap__row--active .timeline-heatmap__bar {
+  opacity: 1;
+}
+
+.timeline-heatmap__count {
+  flex: 0 0 28px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/sherlock/desktop/src/components/Content/TimelineHeatmap.tsx
+++ b/sherlock/desktop/src/components/Content/TimelineHeatmap.tsx
@@ -1,0 +1,89 @@
+/**
+ * TimelineHeatmap — compact vertical timeline sidebar widget.
+ *
+ * Shows one row per month (YYYY-MM), with bar width proportional to count.
+ * Clicking a month injects a `from:YYYY-MM-01 to:YYYY-MM-last` token into the query.
+ */
+import { useEffect, useState } from "react";
+import { listTimelineBuckets } from "../../api";
+import type { TimelineBucket } from "../../types";
+import "./TimelineHeatmap.css";
+
+/** Return the last day of a YYYY-MM string. */
+function lastDay(bucket: string): string {
+  const [y, m] = bucket.split("-").map(Number);
+  const d = new Date(y, m, 0); // day 0 of next month = last day of current month
+  return `${bucket}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** Short month label, e.g. "Jun '23". */
+function monthLabel(bucket: string): string {
+  const [y, m] = bucket.split("-").map(Number);
+  const date = new Date(y, m - 1, 1);
+  const short = date.toLocaleString("en", { month: "short" });
+  return `${short} '${String(y).slice(-2)}`;
+}
+
+type Props = {
+  onQueryChange: (query: string) => void;
+};
+
+export default function TimelineHeatmap({ onQueryChange }: Props) {
+  const [buckets, setBuckets] = useState<TimelineBucket[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeBucket, setActiveBucket] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    listTimelineBuckets()
+      .then(setBuckets)
+      .catch(() => setBuckets([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="timeline-heatmap__empty">Loading…</p>;
+  if (!buckets.length) return <p className="timeline-heatmap__empty">No photos yet</p>;
+
+  const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+
+  const handleClick = (bucket: string) => {
+    if (activeBucket === bucket) {
+      // Deselect: clear the date range
+      setActiveBucket(null);
+      onQueryChange("");
+    } else {
+      setActiveBucket(bucket);
+      const from = `${bucket}-01`;
+      const to = lastDay(bucket);
+      onQueryChange(`${from} ${to}`);
+    }
+  };
+
+  return (
+    <div className="timeline-heatmap" aria-label="Photo timeline">
+      {buckets.map((b) => {
+        const pct = Math.max(8, Math.round((b.count / maxCount) * 100));
+        const isActive = activeBucket === b.bucket;
+        return (
+          <button
+            key={b.bucket}
+            className={`timeline-heatmap__row${isActive ? " timeline-heatmap__row--active" : ""}`}
+            type="button"
+            onClick={() => handleClick(b.bucket)}
+            title={`${b.bucket}: ${b.count} photos`}
+            aria-pressed={isActive}
+          >
+            <span className="timeline-heatmap__label">{monthLabel(b.bucket)}</span>
+            <span className="timeline-heatmap__bar-wrap">
+              <span
+                className="timeline-heatmap__bar"
+                style={{ width: `${pct}%` }}
+              />
+            </span>
+            <span className="timeline-heatmap__count">{b.count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/sherlock/desktop/src/components/Content/Toolbar.tsx
+++ b/sherlock/desktop/src/components/Content/Toolbar.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { SortField, SortOrder } from "../../types";
+import ChipSearchBar from "../Search/ChipSearchBar";
 
 type Props = {
   query: string;
@@ -46,12 +47,10 @@ export default function Toolbar({
 
   return (
     <div className="toolbar">
-      <input
-        type="search"
+      <ChipSearchBar
+        query={query}
+        onQueryChange={onQueryChange}
         placeholder="e.g. photo beach sunset — F1 for help"
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        aria-label="Search query"
       />
       {hasTextQuery && onSaveSmartFolder && (
         <button

--- a/sherlock/desktop/src/components/Content/Toolbar.tsx
+++ b/sherlock/desktop/src/components/Content/Toolbar.tsx
@@ -2,6 +2,28 @@ import { useEffect } from "react";
 import type { SortField, SortOrder } from "../../types";
 import ChipSearchBar from "../Search/ChipSearchBar";
 
+/** Extract current blur filter state from query string */
+function getBlurState(query: string): "none" | "sharp" | "blurry" {
+  if (/\bblur:false\b/i.test(query)) return "sharp";
+  if (/\bblur:true\b/i.test(query)) return "blurry";
+  return "none";
+}
+
+/** Cycle blur filter state: none → sharp → blurry → none */
+function cycleBlurState(current: "none" | "sharp" | "blurry"): "none" | "sharp" | "blurry" {
+  if (current === "none") return "sharp";
+  if (current === "sharp") return "blurry";
+  return "none";
+}
+
+/** Replace or remove the blur token in a query string */
+function setBlurInQuery(query: string, state: "none" | "sharp" | "blurry"): string {
+  const stripped = query.replace(/\s*blur:(true|false)/gi, "").trim();
+  if (state === "sharp") return (stripped + " blur:false").trim();
+  if (state === "blurry") return (stripped + " blur:true").trim();
+  return stripped;
+}
+
 type Props = {
   query: string;
   onQueryChange: (value: string) => void;
@@ -44,6 +66,18 @@ export default function Toolbar({
       onSortByChange("dateModified");
     }
   }, [hasTextQuery, sortBy, onSortByChange]);
+
+  const blurState = getBlurState(query);
+
+  function handleBlurToggle() {
+    const next = cycleBlurState(blurState);
+    onQueryChange(setBlurInQuery(query, next));
+  }
+
+  const blurLabel =
+    blurState === "none" ? "Blur: all" :
+    blurState === "sharp" ? "Blur: hide blurry" :
+    "Blur: only blurry";
 
   return (
     <div className="toolbar">
@@ -102,6 +136,15 @@ export default function Toolbar({
           {sortOrder === "asc" ? "\u2191" : "\u2193"}
         </button>
       )}
+      <button
+        className={`toolbar-blur-toggle${blurState !== "none" ? " toolbar-blur-active" : ""}`}
+        onClick={handleBlurToggle}
+        title={blurLabel}
+        aria-label={blurLabel}
+        aria-pressed={blurState !== "none"}
+      >
+        {blurState === "blurry" ? "~Blurry" : blurState === "sharp" ? "~Sharp" : "~"}
+      </button>
     </div>
   );
 }

--- a/sherlock/desktop/src/components/Content/Toolbar.tsx
+++ b/sherlock/desktop/src/components/Content/Toolbar.tsx
@@ -36,6 +36,7 @@ type Props = {
   onSortOrderChange: (value: SortOrder) => void;
   hasTextQuery: boolean;
   onSaveSmartFolder?: () => void;
+  onSaveSearch?: () => void;
 };
 
 const sortOptions: { value: SortField; label: string; icon: JSX.Element; requiresQuery?: boolean }[] = [
@@ -60,6 +61,7 @@ const sortOptions: { value: SortField; label: string; icon: JSX.Element; require
 export default function Toolbar({
   query, onQueryChange, selectedMediaType, onMediaTypeChange, mediaTypeOptions,
   sortBy, onSortByChange, sortOrder, onSortOrderChange, hasTextQuery, onSaveSmartFolder,
+  onSaveSearch,
 }: Props) {
   useEffect(() => {
     if (!hasTextQuery && sortBy === "relevance") {
@@ -95,6 +97,18 @@ export default function Toolbar({
         >
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M2 1h10l3 3v10a1 1 0 01-1 1H2a1 1 0 01-1-1V2a1 1 0 011-1zm2 0v4h7V1H4zm4 6a2.5 2.5 0 100 5 2.5 2.5 0 000-5z"/>
+          </svg>
+        </button>
+      )}
+      {hasTextQuery && onSaveSearch && (
+        <button
+          className="toolbar-save-btn"
+          onClick={onSaveSearch}
+          title="Save Search"
+          aria-label="Save Search"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11zm0 2a.75.75 0 00-.75.75v2.5H5.75a.75.75 0 000 1.5h1.5v2.5a.75.75 0 001.5 0v-2.5h1.5a.75.75 0 000-1.5H8.75v-2.5A.75.75 0 008 4.5z"/>
           </svg>
         </button>
       )}

--- a/sherlock/desktop/src/components/Search/ChipSearchBar.css
+++ b/sherlock/desktop/src/components/Search/ChipSearchBar.css
@@ -1,0 +1,179 @@
+/* ── ChipSearchBar ────────────────────────────────────────────── */
+.chip-search-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  padding: 3px 6px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  position: relative;
+  cursor: text;
+}
+
+.chip-search-bar:focus-within {
+  border-color: var(--accent);
+  outline: none;
+}
+
+/* ── Chips ── */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-family: monospace;
+  white-space: nowrap;
+  max-width: 200px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  color: var(--text-primary);
+}
+
+/* Per-facet accent dots */
+.chip--camera  { border-left: 3px solid #5b8cff; }
+.chip--lens    { border-left: 3px solid #9b7fff; }
+.chip--time    { border-left: 3px solid #ff9d5c; }
+.chip--person  { border-left: 3px solid #6ab04c; }
+.chip--album   { border-left: 3px solid #f9ca24; }
+.chip--subdir  { border-left: 3px solid #74b9ff; }
+.chip--media   { border-left: 3px solid #fd79a8; }
+
+.chip--pending {
+  background: var(--bg-hover);
+  border-style: dashed;
+}
+
+.chip__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chip__facet {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+}
+
+.chip__value {
+  color: var(--text-primary);
+}
+
+.chip__delete {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.chip__delete:hover {
+  color: var(--text-primary);
+}
+
+/* ── Pending input inside chip ── */
+.chip__pending-wrapper {
+  position: relative;
+}
+
+.chip__pending-input {
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 0.75rem;
+  font-family: monospace;
+  color: var(--text-primary);
+  width: 100px;
+  min-width: 60px;
+}
+
+.chip__autocomplete-anchor {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 200px;
+  z-index: 200;
+}
+
+/* ── Free-text input ── */
+.chip-search-bar__input-wrapper {
+  flex: 1;
+  min-width: 80px;
+  position: relative;
+}
+
+.chip-search-bar__input {
+  width: 100%;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  padding: 1px 0;
+}
+
+.chip-search-bar__autocomplete-anchor {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 200;
+}
+
+/* ── Facet button ── */
+.chip-search-bar__facet-btn {
+  flex: 0 0 auto;
+  background: none;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 1px 5px;
+}
+
+.chip-search-bar__facet-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── Facet dropdown menu ── */
+.chip-search-bar__facet-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 300;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  min-width: 120px;
+}
+
+.chip-search-bar__facet-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 5px 14px;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.chip-search-bar__facet-option:hover {
+  background: var(--bg-hover);
+  color: var(--accent);
+}

--- a/sherlock/desktop/src/components/Search/ChipSearchBar.tsx
+++ b/sherlock/desktop/src/components/Search/ChipSearchBar.tsx
@@ -1,0 +1,340 @@
+/**
+ * ChipSearchBar — replaces the plain <input> in Toolbar.
+ *
+ * UX: user types free text. Typing "camera:" (with colon) converts the token
+ * into a coloured chip with an inline value field. Pressing Enter or Space
+ * finalises the chip. Delete via × button or Backspace on empty input.
+ *
+ * The component serialises chips + free text back to the same query string
+ * format the Rust parser already understands (e.g. `camera:"Sony A7" time:morning`).
+ */
+import { useCallback, useEffect, useId, useReducer, useRef, useState } from "react";
+import type { SearchChip } from "../../types";
+import TagAutocomplete from "./TagAutocomplete";
+import "./ChipSearchBar.css";
+
+const FACETS = ["camera", "lens", "time", "person", "album", "subdir", "media"] as const;
+type Facet = (typeof FACETS)[number];
+
+const FACET_LABELS: Record<Facet, string> = {
+  camera: "Camera",
+  lens: "Lens",
+  time: "Time",
+  person: "Person",
+  album: "Album",
+  subdir: "Folder",
+  media: "Type",
+};
+
+// ── Reducer ──────────────────────────────────────────────────────────
+
+type State = {
+  chips: SearchChip[];
+  freeText: string;
+  /** When non-null, the user is typing the value for a pending chip */
+  pendingFacet: Facet | null;
+  pendingValue: string;
+};
+
+type Action =
+  | { type: "SET_FREE_TEXT"; text: string }
+  | { type: "START_CHIP"; facet: Facet }
+  | { type: "SET_PENDING_VALUE"; value: string }
+  | { type: "COMMIT_CHIP" }
+  | { type: "CANCEL_PENDING" }
+  | { type: "DELETE_CHIP"; id: string }
+  | { type: "RESET"; query: string };
+
+function parseQueryToState(query: string): State {
+  const chips: SearchChip[] = [];
+  let remaining = query;
+
+  // Extract known facet tokens, e.g. camera:"Sony A7" or lens:50mm
+  for (const facet of FACETS) {
+    const re = new RegExp(`\\b${facet}:(?:"([^"]*?)"|([^\\s]+))`, "gi");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(remaining)) !== null) {
+      chips.push({ id: `${facet}-${Date.now()}-${Math.random()}`, facet, value: m[1] ?? m[2] ?? "" });
+    }
+    remaining = remaining.replace(re, "").trim();
+  }
+
+  return { chips, freeText: remaining, pendingFacet: null, pendingValue: "" };
+}
+
+function serializeState(state: State): string {
+  const parts: string[] = [];
+  for (const chip of state.chips) {
+    const val = chip.value.includes(" ") ? `"${chip.value}"` : chip.value;
+    parts.push(`${chip.facet}:${val}`);
+  }
+  if (state.freeText.trim()) parts.push(state.freeText.trim());
+  return parts.join(" ");
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "SET_FREE_TEXT":
+      return { ...state, freeText: action.text };
+
+    case "START_CHIP":
+      return { ...state, pendingFacet: action.facet, pendingValue: "", freeText: state.freeText };
+
+    case "SET_PENDING_VALUE":
+      return { ...state, pendingValue: action.value };
+
+    case "COMMIT_CHIP": {
+      if (!state.pendingFacet || !state.pendingValue.trim()) {
+        return { ...state, pendingFacet: null, pendingValue: "" };
+      }
+      const chip: SearchChip = {
+        id: `${state.pendingFacet}-${Date.now()}`,
+        facet: state.pendingFacet,
+        value: state.pendingValue.trim(),
+      };
+      return { ...state, chips: [...state.chips, chip], pendingFacet: null, pendingValue: "" };
+    }
+
+    case "CANCEL_PENDING":
+      return { ...state, pendingFacet: null, pendingValue: "" };
+
+    case "DELETE_CHIP":
+      return { ...state, chips: state.chips.filter((c) => c.id !== action.id) };
+
+    case "RESET":
+      return parseQueryToState(action.query);
+
+    default:
+      return state;
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────
+
+type Props = {
+  query: string;
+  onQueryChange: (query: string) => void;
+  placeholder?: string;
+};
+
+export default function ChipSearchBar({ query, onQueryChange, placeholder }: Props) {
+  const uid = useId();
+  const [state, dispatch] = useReducer(reducer, query, parseQueryToState);
+  const [showFacetMenu, setShowFacetMenu] = useState(false);
+  const [showAutocomplete, setShowAutocomplete] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const pendingRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const syncingRef = useRef(false);
+
+  // Keep state in sync when query changes from outside (e.g. sidebar album click)
+  useEffect(() => {
+    if (syncingRef.current) return;
+    dispatch({ type: "RESET", query });
+  }, [query]);
+
+  // Emit query change upward whenever chips or freeText change
+  const prevQueryRef = useRef(query);
+  useEffect(() => {
+    const serialized = serializeState(state);
+    if (serialized === prevQueryRef.current) return;
+    prevQueryRef.current = serialized;
+    syncingRef.current = true;
+    onQueryChange(serialized);
+    // Reset flag after the parent re-render cycle
+    requestAnimationFrame(() => { syncingRef.current = false; });
+  }, [state, onQueryChange]);
+
+  const handleFreeKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === ":" && !e.ctrlKey && !e.metaKey) {
+      // Check if text before cursor is a known facet
+      const val = (e.target as HTMLInputElement).value;
+      const facet = FACETS.find((f) => val.trimEnd() === f);
+      if (facet) {
+        e.preventDefault();
+        dispatch({ type: "SET_FREE_TEXT", text: "" });
+        dispatch({ type: "START_CHIP", facet });
+        setShowFacetMenu(false);
+        setShowAutocomplete(false);
+        setTimeout(() => pendingRef.current?.focus(), 0);
+        return;
+      }
+    }
+    if (e.key === "Backspace" && !state.freeText && state.chips.length > 0) {
+      // Delete last chip
+      dispatch({ type: "DELETE_CHIP", id: state.chips[state.chips.length - 1].id });
+    }
+    if (e.key === "Escape") setShowAutocomplete(false);
+  }, [state.freeText, state.chips]);
+
+  const handlePendingKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      dispatch({ type: "COMMIT_CHIP" });
+      setShowAutocomplete(false);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+    if (e.key === "Escape") {
+      dispatch({ type: "CANCEL_PENDING" });
+      setShowAutocomplete(false);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, []);
+
+  const handleAutocompleteSelect = useCallback((label: string) => {
+    if (state.pendingFacet) {
+      dispatch({ type: "SET_PENDING_VALUE", value: label });
+      dispatch({ type: "COMMIT_CHIP" });
+      setShowAutocomplete(false);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } else {
+      // Insert into free text
+      dispatch({ type: "SET_FREE_TEXT", text: label });
+      setShowAutocomplete(false);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [state.pendingFacet]);
+
+  return (
+    <div className="chip-search-bar" ref={containerRef} role="search">
+      {/* Rendered chips */}
+      {state.chips.map((chip) => (
+        <span
+          key={chip.id}
+          className={`chip chip--${chip.facet}`}
+          title={`${chip.facet}:${chip.value}`}
+        >
+          <span className="chip__label">
+            <span className="chip__facet">{FACET_LABELS[chip.facet as Facet] ?? chip.facet}</span>
+            {": "}
+            <span className="chip__value">{chip.value}</span>
+          </span>
+          <button
+            className="chip__delete"
+            aria-label={`Remove ${chip.facet} filter`}
+            onClick={() => dispatch({ type: "DELETE_CHIP", id: chip.id })}
+            type="button"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+
+      {/* Pending chip value input */}
+      {state.pendingFacet && (
+        <span className={`chip chip--${state.pendingFacet} chip--pending`}>
+          <span className="chip__facet">{FACET_LABELS[state.pendingFacet as Facet] ?? state.pendingFacet}:</span>
+          <div className="chip__pending-wrapper">
+            <input
+              ref={pendingRef}
+              className="chip__pending-input"
+              value={state.pendingValue}
+              onChange={(e) => {
+                dispatch({ type: "SET_PENDING_VALUE", value: e.target.value });
+                setShowAutocomplete(e.target.value.length > 0);
+              }}
+              onKeyDown={handlePendingKeyDown}
+              onBlur={() => {
+                setTimeout(() => {
+                  if (!containerRef.current?.contains(document.activeElement)) {
+                    dispatch({ type: "COMMIT_CHIP" });
+                    setShowAutocomplete(false);
+                  }
+                }, 150);
+              }}
+              placeholder="type value…"
+              autoComplete="off"
+              aria-label={`${state.pendingFacet} filter value`}
+              aria-autocomplete="list"
+              aria-controls={`${uid}-autocomplete`}
+            />
+            {showAutocomplete && (
+              <div id={`${uid}-autocomplete`} className="chip__autocomplete-anchor">
+                <TagAutocomplete
+                  prefix={state.pendingValue}
+                  onSelect={handleAutocompleteSelect}
+                  onClose={() => setShowAutocomplete(false)}
+                />
+              </div>
+            )}
+          </div>
+        </span>
+      )}
+
+      {/* Free-text input */}
+      {!state.pendingFacet && (
+        <div className="chip-search-bar__input-wrapper">
+          <input
+            ref={inputRef}
+            type="search"
+            className="chip-search-bar__input"
+            value={state.freeText}
+            onChange={(e) => {
+              dispatch({ type: "SET_FREE_TEXT", text: e.target.value });
+              setShowAutocomplete(e.target.value.length > 0);
+              setShowFacetMenu(false);
+            }}
+            onKeyDown={handleFreeKeyDown}
+            onFocus={() => {
+              if (state.freeText.length > 0) setShowAutocomplete(true);
+            }}
+            onBlur={() => {
+              setTimeout(() => {
+                if (!containerRef.current?.contains(document.activeElement)) {
+                  setShowAutocomplete(false);
+                  setShowFacetMenu(false);
+                }
+              }, 150);
+            }}
+            placeholder={state.chips.length === 0 ? (placeholder ?? "Search… (F1 for help)") : ""}
+            autoComplete="off"
+            aria-label="Search query"
+            aria-autocomplete="list"
+            aria-controls={`${uid}-free-autocomplete`}
+          />
+          {showAutocomplete && state.freeText.length > 0 && (
+            <div id={`${uid}-free-autocomplete`} className="chip-search-bar__autocomplete-anchor">
+              <TagAutocomplete
+                prefix={state.freeText}
+                onSelect={handleAutocompleteSelect}
+                onClose={() => setShowAutocomplete(false)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Facet menu toggle */}
+      <button
+        className="chip-search-bar__facet-btn"
+        type="button"
+        title="Add filter…"
+        aria-label="Add filter"
+        aria-expanded={showFacetMenu}
+        onClick={() => setShowFacetMenu((v) => !v)}
+      >
+        +
+      </button>
+      {showFacetMenu && (
+        <ul className="chip-search-bar__facet-menu" role="menu" aria-label="Filter facets">
+          {FACETS.map((facet) => (
+            <li key={facet} role="none">
+              <button
+                role="menuitem"
+                type="button"
+                className="chip-search-bar__facet-option"
+                onClick={() => {
+                  dispatch({ type: "START_CHIP", facet });
+                  setShowFacetMenu(false);
+                  setTimeout(() => pendingRef.current?.focus(), 0);
+                }}
+              >
+                {FACET_LABELS[facet]}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/sherlock/desktop/src/components/Search/TagAutocomplete.css
+++ b/sherlock/desktop/src/components/Search/TagAutocomplete.css
@@ -1,0 +1,52 @@
+/* ── TagAutocomplete dropdown ─────────────────────────────────── */
+.tag-autocomplete {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 200;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.tag-autocomplete__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.tag-autocomplete__item--active {
+  background: var(--bg-hover);
+  color: var(--accent);
+}
+
+.tag-autocomplete__icon {
+  flex: 0 0 16px;
+  font-size: 0.8rem;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.tag-autocomplete__label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-autocomplete__count {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}

--- a/sherlock/desktop/src/components/Search/TagAutocomplete.tsx
+++ b/sherlock/desktop/src/components/Search/TagAutocomplete.tsx
@@ -1,0 +1,107 @@
+/**
+ * TagAutocomplete — dropdown that calls suggest_cmd and surfaces ranked suggestions.
+ *
+ * Props:
+ *   prefix    – the current partial value being typed
+ *   onSelect  – called when the user picks a suggestion (passes the label)
+ *   onClose   – called when the dropdown should dismiss without picking
+ */
+import { useEffect, useRef, useState } from "react";
+import { suggestTags } from "../../api";
+import type { Suggestion } from "../../types";
+import "./TagAutocomplete.css";
+
+type Props = {
+  prefix: string;
+  onSelect: (label: string) => void;
+  onClose: () => void;
+};
+
+const KIND_ICONS: Record<string, string> = {
+  person: "👤",
+  camera: "📷",
+  lens: "🔭",
+  mention: "#",
+};
+
+export default function TagAutocomplete({ prefix, onSelect, onClose }: Props) {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Debounced fetch
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!prefix.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const results = await suggestTags(prefix.trim(), 8);
+        setSuggestions(results);
+        setActiveIndex(0);
+      } catch {
+        setSuggestions([]);
+      }
+    }, 150);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [prefix]);
+
+  // Keyboard navigation — parent binds keyboard events and calls these
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (!suggestions.length) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, suggestions.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        onSelect(suggestions[activeIndex].label);
+      } else if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [suggestions, activeIndex, onSelect, onClose]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (!suggestions.length) return null;
+
+  return (
+    <ul className="tag-autocomplete" role="listbox" ref={listRef} aria-label="Search suggestions">
+      {suggestions.map((s, i) => (
+        <li
+          key={`${s.kind}-${s.label}`}
+          role="option"
+          aria-selected={i === activeIndex}
+          className={`tag-autocomplete__item${i === activeIndex ? " tag-autocomplete__item--active" : ""}`}
+          onMouseDown={(e) => {
+            // mousedown fires before blur, prevents input from losing focus first
+            e.preventDefault();
+            onSelect(s.label);
+          }}
+          onMouseEnter={() => setActiveIndex(i)}
+        >
+          <span className="tag-autocomplete__icon" title={s.kind}>
+            {KIND_ICONS[s.kind] ?? "#"}
+          </span>
+          <span className="tag-autocomplete__label">{s.label}</span>
+          <span className="tag-autocomplete__count">{s.count}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/sherlock/desktop/src/components/Sidebar/RootCard.tsx
+++ b/sherlock/desktop/src/components/Sidebar/RootCard.tsx
@@ -13,13 +13,14 @@ type RootCardProps = {
   onRescan: () => void;
   onRefresh: () => void;
   onCopyPath: () => void;
+  onRemap: () => void;
   onDetectFaces?: () => void;
   onCancelScan?: () => void;
   onResumeScan?: () => void;
   onCancelFaceDetect?: () => void;
 };
 
-export default function RootCard({ root, isSelected, scan, readOnly, faceProgress, onSelect, onDelete, onRescan, onRefresh, onCopyPath, onDetectFaces, onCancelScan, onResumeScan, onCancelFaceDetect }: RootCardProps) {
+export default function RootCard({ root, isSelected, scan, readOnly, faceProgress, onSelect, onDelete, onRescan, onRefresh, onCopyPath, onRemap, onDetectFaces, onCancelScan, onResumeScan, onCancelFaceDetect }: RootCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [menuPos, setMenuPos] = useState({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
@@ -178,6 +179,7 @@ export default function RootCard({ root, isSelected, scan, readOnly, faceProgres
           role="menu"
         >
           <button role="menuitem" onClick={(e) => { e.stopPropagation(); onCopyPath(); setShowMenu(false); }}>Copy Path</button>
+          <button role="menuitem" onClick={(e) => { e.stopPropagation(); onRemap(); setShowMenu(false); }}>Remap Path…</button>
           <button role="menuitem" onClick={(e) => { e.stopPropagation(); onRefresh(); setShowMenu(false); }}>Refresh Metadata</button>
           <button role="menuitem" onClick={(e) => { e.stopPropagation(); onRescan(); setShowMenu(false); }}>Rescan</button>
           {onDetectFaces && (

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.css
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.css
@@ -447,3 +447,65 @@
   color: var(--text-secondary);
   font-style: italic;
 }
+
+/* ── Saved searches ──────────────────────────────────────────── */
+.saved-search-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 8px;
+}
+
+.saved-search-name {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 0;
+}
+
+.saved-search-name:hover {
+  color: var(--accent);
+}
+
+.saved-search-bell {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  opacity: 0.4;
+  padding: 2px 3px;
+  border-radius: 3px;
+  line-height: 1;
+}
+
+.saved-search-bell.active {
+  opacity: 1;
+}
+
+.saved-search-bell:hover {
+  opacity: 0.9;
+}
+
+.saved-search-delete {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--text-muted, #888);
+  padding: 2px 4px;
+  border-radius: 3px;
+  line-height: 1;
+}
+
+.saved-search-delete:hover {
+  color: var(--danger, #e06c6c);
+  background: var(--danger-bg, #3a1a1a);
+}

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import type { Album, DbStats, FaceDetectProgress, RootInfo, ScanJobStatus, SmartFolder, UpdateInfo } from "../../types";
+import type { Album, DbStats, FaceDetectProgress, RootInfo, ScanJobStatus, SavedSearch, SmartFolder, UpdateInfo } from "../../types";
 import { formatBytes } from "../../utils/format";
 import { useDragReorder } from "../../hooks/useDragReorder";
 import RootCard from "./RootCard";
@@ -54,6 +54,10 @@ type SidebarProps = {
   onCheckUpdates?: () => void;
   onInstallUpdate?: () => void;
   onTimelineQueryChange?: (query: string) => void;
+  savedSearches?: SavedSearch[];
+  onSelectSavedSearch?: (search: SavedSearch) => void;
+  onDeleteSavedSearch?: (search: SavedSearch) => void;
+  onToggleSavedSearchNotify?: (search: SavedSearch) => void;
 };
 
 export default function Sidebar({
@@ -70,6 +74,7 @@ export default function Sidebar({
   updateInfo, updateChecking, updateDownloading, updateProgress,
   onCheckUpdates, onInstallUpdate,
   onTimelineQueryChange,
+  savedSearches, onSelectSavedSearch, onDeleteSavedSearch, onToggleSavedSearchNotify,
 }: SidebarProps) {
   const rootsDrag = useDragReorder({ items: roots, onReorder: onReorderRoots ?? (() => {}), readOnly });
   const albumsDrag = useDragReorder({ items: albums, onReorder: onReorderAlbums ?? (() => {}), readOnly });
@@ -172,6 +177,44 @@ export default function Sidebar({
                   </div>
                 );
               })}
+            </div>
+          </>
+        )}
+
+        {savedSearches && savedSearches.length > 0 && (
+          <>
+            <div className="sidebar-section"><span>Saved Searches</span></div>
+            <div className="root-list">
+              {savedSearches.map((s) => (
+                <div key={s.id} className="saved-search-row">
+                  <button
+                    type="button"
+                    className="saved-search-name"
+                    onClick={() => onSelectSavedSearch?.(s)}
+                    title={s.query}
+                  >
+                    {s.name}
+                  </button>
+                  <button
+                    type="button"
+                    className={`saved-search-bell${s.notify ? " active" : ""}`}
+                    title={s.notify ? "Disable alerts" : "Enable alerts"}
+                    onClick={() => onToggleSavedSearchNotify?.(s)}
+                    aria-label={s.notify ? "Disable alert" : "Enable alert"}
+                  >
+                    🔔
+                  </button>
+                  <button
+                    type="button"
+                    className="saved-search-delete"
+                    title="Delete saved search"
+                    onClick={() => onDeleteSavedSearch?.(s)}
+                    aria-label="Delete saved search"
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
             </div>
           </>
         )}

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import RootCard from "./RootCard";
 import AlbumCard from "./AlbumCard";
 import SmartFolderCard from "./SmartFolderCard";
 import DirectoryTree from "./DirectoryTree";
+import TimelineHeatmap from "../Content/TimelineHeatmap";
 import "./Sidebar.css";
 
 type SidebarProps = {
@@ -50,6 +51,7 @@ type SidebarProps = {
   updateProgress?: { downloaded: number; total: number | null } | null;
   onCheckUpdates?: () => void;
   onInstallUpdate?: () => void;
+  onTimelineQueryChange?: (query: string) => void;
 };
 
 export default function Sidebar({
@@ -65,6 +67,7 @@ export default function Sidebar({
   onExportCatalog, onImportCatalog,
   updateInfo, updateChecking, updateDownloading, updateProgress,
   onCheckUpdates, onInstallUpdate,
+  onTimelineQueryChange,
 }: SidebarProps) {
   const rootsDrag = useDragReorder({ items: roots, onReorder: onReorderRoots ?? (() => {}), readOnly });
   const albumsDrag = useDragReorder({ items: albums, onReorder: onReorderAlbums ?? (() => {}), readOnly });
@@ -168,6 +171,13 @@ export default function Sidebar({
                 );
               })}
             </div>
+          </>
+        )}
+
+        {onTimelineQueryChange && (
+          <>
+            <div className="sidebar-section"><span>Timeline</span></div>
+            <TimelineHeatmap onQueryChange={onTimelineQueryChange} />
           </>
         )}
       </div>

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -45,6 +45,7 @@ type SidebarProps = {
   onOpenFaces?: () => void;
   onExportCatalog?: () => void;
   onImportCatalog?: () => void;
+  onGenerateYearReview?: () => void;
   updateInfo?: UpdateInfo | null;
   updateChecking?: boolean;
   updateDownloading?: boolean;
@@ -64,7 +65,7 @@ export default function Sidebar({
   onSelectAlbum, onDeleteAlbum, onSelectSmartFolder, onDeleteSmartFolder,
   onReorderRoots, onReorderAlbums, onReorderSmartFolders, onFindDuplicates,
   onOpenPdfPasswords, onOpenFaces,
-  onExportCatalog, onImportCatalog,
+  onExportCatalog, onImportCatalog, onGenerateYearReview,
   updateInfo, updateChecking, updateDownloading, updateProgress,
   onCheckUpdates, onInstallUpdate,
   onTimelineQueryChange,
@@ -182,7 +183,7 @@ export default function Sidebar({
         )}
       </div>
 
-      {(onFindDuplicates || onOpenPdfPasswords || onOpenFaces || onExportCatalog || onImportCatalog || onCheckUpdates) && (
+      {(onFindDuplicates || onGenerateYearReview || onOpenPdfPasswords || onOpenFaces || onExportCatalog || onImportCatalog || onCheckUpdates) && (
         <div className="sidebar-tools-fixed">
           <div className="sidebar-section"><span>Tools</span></div>
           <div className="sidebar-tool-list">
@@ -194,6 +195,16 @@ export default function Sidebar({
                 title="Find duplicate files across all folders"
               >
                 Find Duplicates
+              </button>
+            )}
+            {onGenerateYearReview && (
+              <button
+                type="button"
+                className="sidebar-tool-btn"
+                onClick={onGenerateYearReview}
+                title={`Generate a Year in Review album for ${new Date().getFullYear()}`}
+              >
+                Year in Review
               </button>
             )}
             {onOpenPdfPasswords && (

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -27,6 +27,7 @@ type SidebarProps = {
   onRescanRoot: (root: RootInfo) => void;
   onRefreshRoot: (root: RootInfo) => void;
   onCopyRootPath: (root: RootInfo) => void;
+  onRemapRoot: (root: RootInfo) => void;
   onDetectFaces: (root: RootInfo) => void;
   onCancelFaceDetect: () => void;
   onCancelScan: (scan: ScanJobStatus) => void;
@@ -53,7 +54,7 @@ export default function Sidebar({
   roots, selectedRootId, activeScans, dbStats, readOnly,
   setupReady, albums, smartFolders, activeAlbumName, activeSmartFolderId,
   selectedSubdir, faceProgress, onSelectSubdir,
-  onSelectRoot, onDeleteRoot, onRescanRoot, onRefreshRoot, onCopyRootPath, onPickAndScan,
+  onSelectRoot, onDeleteRoot, onRescanRoot, onRefreshRoot, onCopyRootPath, onRemapRoot, onPickAndScan,
   onDetectFaces, onCancelFaceDetect,
   onCancelScan, onResumeScan,
   onSelectAlbum, onDeleteAlbum, onSelectSmartFolder, onDeleteSmartFolder,
@@ -107,6 +108,7 @@ export default function Sidebar({
                   onRescan={() => onRescanRoot(root)}
                   onRefresh={() => onRefreshRoot(root)}
                   onCopyPath={() => onCopyRootPath(root)}
+                  onRemap={() => onRemapRoot(root)}
                   onDetectFaces={!readOnly ? () => onDetectFaces(root) : undefined}
                   onCancelScan={scan?.status === "running" ? () => onCancelScan(scan) : undefined}
                   onResumeScan={scan?.status === "interrupted" ? () => onResumeScan(scan) : undefined}

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -46,6 +46,7 @@ type SidebarProps = {
   onExportCatalog?: () => void;
   onImportCatalog?: () => void;
   onGenerateYearReview?: () => void;
+  onOpenTagRules?: () => void;
   updateInfo?: UpdateInfo | null;
   updateChecking?: boolean;
   updateDownloading?: boolean;
@@ -65,7 +66,7 @@ export default function Sidebar({
   onSelectAlbum, onDeleteAlbum, onSelectSmartFolder, onDeleteSmartFolder,
   onReorderRoots, onReorderAlbums, onReorderSmartFolders, onFindDuplicates,
   onOpenPdfPasswords, onOpenFaces,
-  onExportCatalog, onImportCatalog, onGenerateYearReview,
+  onExportCatalog, onImportCatalog, onGenerateYearReview, onOpenTagRules,
   updateInfo, updateChecking, updateDownloading, updateProgress,
   onCheckUpdates, onInstallUpdate,
   onTimelineQueryChange,
@@ -183,7 +184,7 @@ export default function Sidebar({
         )}
       </div>
 
-      {(onFindDuplicates || onGenerateYearReview || onOpenPdfPasswords || onOpenFaces || onExportCatalog || onImportCatalog || onCheckUpdates) && (
+      {(onFindDuplicates || onGenerateYearReview || onOpenTagRules || onOpenPdfPasswords || onOpenFaces || onExportCatalog || onImportCatalog || onCheckUpdates) && (
         <div className="sidebar-tools-fixed">
           <div className="sidebar-section"><span>Tools</span></div>
           <div className="sidebar-tool-list">
@@ -205,6 +206,16 @@ export default function Sidebar({
                 title={`Generate a Year in Review album for ${new Date().getFullYear()}`}
               >
                 Year in Review
+              </button>
+            )}
+            {onOpenTagRules && (
+              <button
+                type="button"
+                className="sidebar-tool-btn"
+                onClick={onOpenTagRules}
+                title="Manage path-pattern auto-tag rules"
+              >
+                Tag Rules…
               </button>
             )}
             {onOpenPdfPasswords && (

--- a/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
+++ b/sherlock/desktop/src/components/Sidebar/Sidebar.tsx
@@ -42,6 +42,8 @@ type SidebarProps = {
   onFindDuplicates?: () => void;
   onOpenPdfPasswords?: () => void;
   onOpenFaces?: () => void;
+  onExportCatalog?: () => void;
+  onImportCatalog?: () => void;
   updateInfo?: UpdateInfo | null;
   updateChecking?: boolean;
   updateDownloading?: boolean;
@@ -60,6 +62,7 @@ export default function Sidebar({
   onSelectAlbum, onDeleteAlbum, onSelectSmartFolder, onDeleteSmartFolder,
   onReorderRoots, onReorderAlbums, onReorderSmartFolders, onFindDuplicates,
   onOpenPdfPasswords, onOpenFaces,
+  onExportCatalog, onImportCatalog,
   updateInfo, updateChecking, updateDownloading, updateProgress,
   onCheckUpdates, onInstallUpdate,
 }: SidebarProps) {
@@ -169,7 +172,7 @@ export default function Sidebar({
         )}
       </div>
 
-      {(onFindDuplicates || onOpenPdfPasswords || onOpenFaces || onCheckUpdates) && (
+      {(onFindDuplicates || onOpenPdfPasswords || onOpenFaces || onExportCatalog || onImportCatalog || onCheckUpdates) && (
         <div className="sidebar-tools-fixed">
           <div className="sidebar-section"><span>Tools</span></div>
           <div className="sidebar-tool-list">
@@ -201,6 +204,26 @@ export default function Sidebar({
                 title="Browse images with detected faces"
               >
                 Faces
+              </button>
+            )}
+            {onExportCatalog && (
+              <button
+                type="button"
+                className="sidebar-tool-btn"
+                onClick={onExportCatalog}
+                title="Export the catalog (DB + thumbnails + classifications) to a zip file"
+              >
+                Export Catalog…
+              </button>
+            )}
+            {onImportCatalog && (
+              <button
+                type="button"
+                className="sidebar-tool-btn"
+                onClick={onImportCatalog}
+                title="Restore a previously exported catalog"
+              >
+                Import Catalog…
               </button>
             )}
             {onCheckUpdates && (

--- a/sherlock/desktop/src/components/modals/ExportCatalogModal.css
+++ b/sherlock/desktop/src/components/modals/ExportCatalogModal.css
@@ -1,0 +1,37 @@
+/* ── Export catalog modal ─────────────────────────────────── */
+.export-catalog-modal {
+  width: min(520px, 92%);
+}
+
+.export-catalog-status {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  margin: 0 0 10px;
+}
+
+.export-catalog-path {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+  word-break: break-all;
+}
+
+.export-catalog-path code {
+  background: var(--bg-input);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85em;
+}
+
+.export-catalog-error {
+  color: var(--danger);
+  font-size: 0.8rem;
+  margin: 0 0 10px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  word-break: break-word;
+}

--- a/sherlock/desktop/src/components/modals/ExportCatalogModal.tsx
+++ b/sherlock/desktop/src/components/modals/ExportCatalogModal.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
+import { openPath } from "@tauri-apps/plugin-opener";
+import { errorMessage } from "../../utils";
+import { formatBytes } from "../../utils/format";
+import ModalOverlay from "./ModalOverlay";
+import "./shared-modal.css";
+import "./ExportCatalogModal.css";
+
+interface ExportReport {
+  zipPath: string;
+  entries: number;
+  bytes: number;
+}
+
+type Props = { onClose: () => void };
+
+function parentDir(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return i >= 0 ? p.slice(0, i) : p;
+}
+
+export default function ExportCatalogModal({ onClose }: Props) {
+  const [busy, setBusy] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<ExportReport | null>(null);
+  // Prevent React StrictMode double-invocation from firing two save dialogs.
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const target = await save({
+          defaultPath: "frank_sherlock_catalog.zip",
+          filters: [{ name: "Zip", extensions: ["zip"] }],
+        });
+        if (cancelled) return;
+        if (!target) {
+          onClose();
+          return;
+        }
+        const result = await invoke<ExportReport>("export_catalog_cmd", { outZip: target });
+        if (cancelled) return;
+        setReport(result);
+      } catch (e) {
+        if (cancelled) return;
+        setError(errorMessage(e));
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [onClose]);
+
+  async function handleOpenFolder() {
+    if (!report) return;
+    try {
+      await openPath(parentDir(report.zipPath));
+    } catch (e) {
+      setError(errorMessage(e));
+    }
+  }
+
+  return (
+    <ModalOverlay onBackdropClick={busy ? undefined : onClose}>
+      <div
+        className="modal-base export-catalog-modal"
+        role="dialog"
+        aria-label="Export catalog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3>Export Catalog</h3>
+        {busy && !error && !report && (
+          <p className="export-catalog-status">Exporting catalog…</p>
+        )}
+        {report && (
+          <>
+            <p className="export-catalog-status">
+              Exported <strong>{report.entries.toLocaleString()}</strong> file
+              {report.entries === 1 ? "" : "s"} ({formatBytes(report.bytes)}).
+            </p>
+            <p className="export-catalog-path">
+              <code>{report.zipPath}</code>
+            </p>
+          </>
+        )}
+        {error && (
+          <div role="alert" className="export-catalog-error">
+            {error}
+          </div>
+        )}
+        <div className="modal-actions">
+          {report && (
+            <button type="button" onClick={handleOpenFolder}>
+              Open folder
+            </button>
+          )}
+          <button type="button" onClick={onClose} disabled={busy}>
+            {report || error ? "Close" : "Cancel"}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/sherlock/desktop/src/components/modals/HelpModal.css
+++ b/sherlock/desktop/src/components/modals/HelpModal.css
@@ -38,6 +38,13 @@
   margin: 8px 0 12px;
 }
 
+.help-note-inline {
+  font-style: italic;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  margin: 4px 0 0;
+}
+
 .help-shortcut {
   margin: 8px 0 0;
   text-align: center;

--- a/sherlock/desktop/src/components/modals/HelpModal.tsx
+++ b/sherlock/desktop/src/components/modals/HelpModal.tsx
@@ -77,6 +77,32 @@ export default function HelpModal({ onClose }: Props) {
         </div>
 
         <div className="help-section">
+          <h4>Camera filter</h4>
+          <div className="help-examples">
+            <code>camera:Sony</code>
+            <code>camera:&quot;Canon EOS R5&quot;</code>
+          </div>
+        </div>
+
+        <div className="help-section">
+          <h4>Lens filter</h4>
+          <div className="help-examples">
+            <code>lens:50mm</code>
+            <code>lens:&quot;RF 24-70mm&quot;</code>
+          </div>
+        </div>
+
+        <div className="help-section">
+          <h4>Time of day</h4>
+          <div className="help-examples">
+            <code>time:morning</code>
+            <code>time:golden</code>
+            <code>time:night</code>
+          </div>
+          <p className="help-note-inline">dawn · morning · noon · afternoon · evening · night</p>
+        </div>
+
+        <div className="help-section">
           <h4>Combined</h4>
           <div className="help-examples">
             <code>anime between 2023 and 2024</code>

--- a/sherlock/desktop/src/components/modals/ImportCatalogModal.css
+++ b/sherlock/desktop/src/components/modals/ImportCatalogModal.css
@@ -1,0 +1,37 @@
+/* ── Import catalog modal ─────────────────────────────────── */
+.import-catalog-modal {
+  width: min(520px, 92%);
+}
+
+.import-catalog-warning {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+}
+
+.import-catalog-status {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  margin: 0 0 10px;
+}
+
+.import-catalog-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+}
+
+.import-catalog-error {
+  color: var(--danger);
+  font-size: 0.8rem;
+  margin: 0 0 10px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  word-break: break-word;
+}

--- a/sherlock/desktop/src/components/modals/ImportCatalogModal.tsx
+++ b/sherlock/desktop/src/components/modals/ImportCatalogModal.tsx
@@ -87,6 +87,11 @@ export default function ImportCatalogModal({ onClose }: Props) {
             <p className="import-catalog-hint">
               Restart recommended so the app picks up the restored catalog.
             </p>
+            <p className="import-catalog-hint">
+              If the bundle came from a different machine or drive letter,
+              thumbnails may appear broken — right-click each root and use
+              <strong> Remap Path…</strong> to point it at the new location.
+            </p>
             <div className="modal-actions">
               <button type="button" onClick={onClose}>Close</button>
             </div>

--- a/sherlock/desktop/src/components/modals/ImportCatalogModal.tsx
+++ b/sherlock/desktop/src/components/modals/ImportCatalogModal.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { errorMessage } from "../../utils";
+import { formatBytes } from "../../utils/format";
+import ModalOverlay from "./ModalOverlay";
+import "./shared-modal.css";
+import "./ImportCatalogModal.css";
+
+interface ImportReport {
+  entries: number;
+  bytes: number;
+}
+
+type Props = { onClose: () => void };
+
+type Step = "confirm" | "busy" | "success" | "error";
+
+export default function ImportCatalogModal({ onClose }: Props) {
+  const [step, setStep] = useState<Step>("confirm");
+  const [report, setReport] = useState<ImportReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleChooseFile() {
+    try {
+      const picked = await open({
+        filters: [{ name: "Zip", extensions: ["zip"] }],
+        multiple: false,
+      });
+      const bundle = typeof picked === "string" ? picked : null;
+      if (!bundle) {
+        // Treat cancel as stay-on-confirm so the user can retry or cancel explicitly.
+        return;
+      }
+      setStep("busy");
+      setError(null);
+      const result = await invoke<ImportReport>("import_catalog_cmd", { bundle });
+      setReport(result);
+      setStep("success");
+    } catch (e) {
+      setError(errorMessage(e));
+      setStep("error");
+    }
+  }
+
+  const showExistingCatalogHint =
+    step === "error" && !!error && /refusing to overwrite existing catalog/i.test(error);
+
+  return (
+    <ModalOverlay onBackdropClick={step === "busy" ? undefined : onClose}>
+      <div
+        className="modal-base import-catalog-modal"
+        role="dialog"
+        aria-label="Import catalog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3>Import Catalog</h3>
+
+        {step === "confirm" && (
+          <>
+            <p className="import-catalog-warning">
+              Importing will restore a catalog bundle into this installation. If a
+              catalog already exists here, the import will be refused.
+            </p>
+            <div className="modal-actions">
+              <button type="button" onClick={onClose}>Cancel</button>
+              <button type="button" onClick={handleChooseFile}>Choose file…</button>
+            </div>
+          </>
+        )}
+
+        {step === "busy" && (
+          <>
+            <p className="import-catalog-status">Importing…</p>
+            <div className="modal-actions">
+              <button type="button" disabled>Close</button>
+            </div>
+          </>
+        )}
+
+        {step === "success" && report && (
+          <>
+            <p className="import-catalog-status">
+              Imported <strong>{report.entries.toLocaleString()}</strong> file
+              {report.entries === 1 ? "" : "s"} ({formatBytes(report.bytes)}).
+            </p>
+            <p className="import-catalog-hint">
+              Restart recommended so the app picks up the restored catalog.
+            </p>
+            <div className="modal-actions">
+              <button type="button" onClick={onClose}>Close</button>
+            </div>
+          </>
+        )}
+
+        {step === "error" && (
+          <>
+            <div role="alert" className="import-catalog-error">
+              {error}
+            </div>
+            {showExistingCatalogHint && (
+              <p className="import-catalog-hint">
+                Tip: export or move the existing catalog first.
+              </p>
+            )}
+            <div className="modal-actions">
+              <button type="button" onClick={onClose}>Close</button>
+              <button type="button" onClick={handleChooseFile}>Try another file…</button>
+            </div>
+          </>
+        )}
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/sherlock/desktop/src/components/modals/PreviewModal.css
+++ b/sherlock/desktop/src/components/modals/PreviewModal.css
@@ -265,3 +265,58 @@
   color: var(--text-secondary);
   font-size: 0.75rem;
 }
+
+/* ── Ambient similar sidebar ─────────────────────────────────── */
+.preview-modal-with-sidebar {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.preview-similar-sidebar {
+  width: 90px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 6px;
+  border-left: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  overflow-y: auto;
+}
+
+.preview-similar-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #888);
+  padding: 0 2px 4px;
+  border-bottom: 1px solid var(--border-subtle, #333);
+}
+
+.preview-similar-thumb {
+  width: 76px;
+  height: 76px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-input);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.preview-similar-thumb:hover {
+  border-color: var(--accent, #4d8fff);
+}
+
+.preview-similar-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.preview-similar-thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  background: var(--bg-secondary);
+}

--- a/sherlock/desktop/src/components/modals/PreviewModal.tsx
+++ b/sherlock/desktop/src/components/modals/PreviewModal.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { getVideoStreamUrl } from "../../api";
-import type { SearchItem } from "../../types";
+import type { SearchItem, SimilarResult } from "../../types";
 import { fileName } from "../../utils/format";
 import { formatBytes } from "../../utils/format";
 import PdfViewer from "../Content/PdfViewer";
@@ -15,7 +16,33 @@ type Props = {
   totalItems: number;
   onClose: () => void;
   onNavigate: (index: number) => void;
+  onNavigateSimilar?: (result: SimilarResult) => void;
 };
+
+/** Fetches similar items with a 300ms debounce. */
+function useAmbientSimilar(fileId: number | null): SimilarResult[] {
+  const [similar, setSimilar] = useState<SimilarResult[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (fileId === null) { setSimilar([]); return; }
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      invoke<SimilarResult[]>("find_similar_cmd", {
+        fileId,
+        limit: 5,
+        minScore: 0.7,
+      })
+        .then((res) => setSimilar(res.filter((r) => r.fileId !== fileId)))
+        .catch(() => setSimilar([]));
+    }, 300);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [fileId]);
+
+  return similar;
+}
 
 function isPdf(item: SearchItem): boolean {
   return /\.pdf$/i.test(item.relPath);
@@ -89,11 +116,17 @@ export default function PreviewModal({
   totalItems,
   onClose,
   onNavigate,
+  onNavigateSimilar,
 }: Props) {
   const { mode, pdfs, images } = detectLayout(previewItems);
   const videoItem = mode === "single-video" ? previewItems[0] : undefined;
   const videoUrl = useVideoStreamUrl(videoItem?.absPath);
   const [videoError, setVideoError] = useState(false);
+
+  // Ambient similar sidebar — only for single-item preview
+  const singleFileId =
+    previewItems.length === 1 && onNavigateSimilar ? previewItems[0].id : null;
+  const ambientSimilar = useAmbientSimilar(singleFileId);
 
   // Reset error when navigating to a different item
   useEffect(() => { setVideoError(false); }, [videoItem?.absPath]);
@@ -129,7 +162,10 @@ export default function PreviewModal({
 
   return (
     <ModalOverlay className="preview-overlay" onBackdropClick={onClose}>
-      <div className="preview-modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className={`preview-modal${ambientSimilar.length > 0 ? " preview-modal-with-sidebar" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
         <button
           className="preview-close"
           onClick={onClose}
@@ -259,6 +295,28 @@ export default function PreviewModal({
                   <span className="preview-collage-label">{idx + 1}</span>
                 )}
               </div>
+            ))}
+          </div>
+        )}
+
+        {/* Ambient similar sidebar */}
+        {ambientSimilar.length > 0 && onNavigateSimilar && (
+          <div className="preview-similar-sidebar" data-testid="ambient-similar-sidebar">
+            <div className="preview-similar-title">Similar</div>
+            {ambientSimilar.map((result) => (
+              <button
+                key={result.fileId}
+                type="button"
+                className="preview-similar-thumb"
+                title={result.relPath}
+                onClick={() => onNavigateSimilar(result)}
+              >
+                {result.thumbPath ? (
+                  <img src={convertFileSrc(result.thumbPath)} alt={result.filename} />
+                ) : (
+                  <div className="preview-similar-thumb-placeholder" />
+                )}
+              </button>
             ))}
           </div>
         )}

--- a/sherlock/desktop/src/components/modals/RemapRootModal.css
+++ b/sherlock/desktop/src/components/modals/RemapRootModal.css
@@ -1,0 +1,79 @@
+/* ── Remap root modal ─────────────────────────────────────── */
+.remap-root-modal {
+  width: min(520px, 92%);
+}
+
+.remap-root-subtle {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+  word-break: break-all;
+}
+
+.remap-root-subtle code {
+  background: var(--bg-input);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85em;
+}
+
+.remap-root-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 10px 0;
+}
+
+.remap-root-field span {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.remap-root-field input {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  box-sizing: border-box;
+}
+
+.remap-root-field input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.remap-root-field input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.remap-root-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+}
+
+.remap-root-error {
+  color: var(--danger);
+  font-size: 0.8rem;
+  margin: 0 0 10px;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  word-break: break-word;
+}
+
+.remap-root-success {
+  color: var(--success, #2a7a2a);
+  font-size: var(--font-size-sm);
+  margin: 0 0 10px;
+}

--- a/sherlock/desktop/src/components/modals/RemapRootModal.tsx
+++ b/sherlock/desktop/src/components/modals/RemapRootModal.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { errorMessage } from "../../utils";
+import ModalOverlay from "./ModalOverlay";
+import "./shared-modal.css";
+import "./RemapRootModal.css";
+
+interface RemapReport {
+  rootsUpdated: number;
+  filesUpdated: number;
+  scanJobsUpdated: number;
+}
+
+type Props = {
+  oldPath: string;
+  onClose: () => void;
+  onRemapped: (report: RemapReport) => void;
+};
+
+export default function RemapRootModal({ oldPath, onClose, onRemapped }: Props) {
+  const [newPath, setNewPath] = useState(oldPath);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<RemapReport | null>(null);
+
+  async function submit() {
+    setBusy(true);
+    setError(null);
+    setReport(null);
+    try {
+      const result = await invoke<RemapReport>("remap_root_cmd", { oldPath, newPath });
+      setReport(result);
+      onRemapped(result);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <ModalOverlay onBackdropClick={busy ? undefined : onClose}>
+      <div
+        className="modal-base remap-root-modal"
+        role="dialog"
+        aria-label="Remap root"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3>Remap Root</h3>
+        <p className="remap-root-subtle">
+          Old path: <code>{oldPath}</code>
+        </p>
+        <label className="remap-root-field">
+          <span>New path</span>
+          <input
+            aria-label="new path"
+            value={newPath}
+            onChange={(e) => setNewPath(e.target.value)}
+            disabled={busy}
+            autoFocus
+          />
+        </label>
+        <p className="remap-root-hint">
+          Use this when you've changed a drive letter or moved the folder. The file index stays — no re-scan needed.
+        </p>
+        {error && (
+          <div role="alert" className="remap-root-error">
+            {error}
+          </div>
+        )}
+        {report && (
+          <div className="remap-root-success">
+            Remap complete: {report.filesUpdated.toLocaleString()} file{report.filesUpdated === 1 ? "" : "s"} updated.
+          </div>
+        )}
+        <div className="modal-actions">
+          <button type="button" onClick={onClose} disabled={busy}>
+            {report ? "Close" : "Cancel"}
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={busy || !newPath || newPath === oldPath || report !== null}
+          >
+            {busy ? "Remapping…" : "Remap"}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/sherlock/desktop/src/components/modals/SimilarResultsModal.css
+++ b/sherlock/desktop/src/components/modals/SimilarResultsModal.css
@@ -1,0 +1,78 @@
+.similar-results-modal {
+  min-width: 480px;
+  max-width: 720px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+.similar-results-status,
+.similar-results-empty {
+  color: var(--text-muted, #888);
+  font-size: 0.9em;
+  margin: 0.75rem 0;
+}
+.similar-results-error {
+  color: var(--danger, #b00020);
+  background: rgba(176, 0, 32, 0.08);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  margin: 0.5rem 0;
+}
+.similar-results-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+  max-height: 60vh;
+}
+.similar-results-item {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid var(--border, #333);
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+.similar-results-thumb {
+  width: 64px;
+  height: 64px;
+  background: var(--thumb-bg, #222);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.similar-results-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 3px;
+}
+.similar-results-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+.similar-results-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.similar-results-desc {
+  color: var(--text-muted, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.similar-results-score {
+  font-variant-numeric: tabular-nums;
+  color: var(--accent, #5AC8FA);
+  font-weight: 600;
+  font-size: 0.9em;
+}

--- a/sherlock/desktop/src/components/modals/SimilarResultsModal.tsx
+++ b/sherlock/desktop/src/components/modals/SimilarResultsModal.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { errorMessage } from "../../utils";
+import type { SimilarResult } from "../../types";
+import ModalOverlay from "./ModalOverlay";
+import "./shared-modal.css";
+import "./SimilarResultsModal.css";
+
+type Props = {
+  sourceFileId: number;
+  sourceLabel: string;
+  onClose: () => void;
+};
+
+export default function SimilarResultsModal({ sourceFileId, sourceLabel, onClose }: Props) {
+  const [results, setResults] = useState<SimilarResult[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const out = await invoke<SimilarResult[]>("find_similar_cmd", {
+          fileId: sourceFileId,
+          limit: 20,
+          minScore: 0.5,
+        });
+        if (!cancelled) setResults(out);
+      } catch (e) {
+        if (!cancelled) setError(errorMessage(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [sourceFileId]);
+
+  return (
+    <ModalOverlay onBackdropClick={onClose}>
+      <div
+        className="modal-base similar-results-modal"
+        role="dialog"
+        aria-label="Similar results"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3>Similar to {sourceLabel}</h3>
+        {error && <div role="alert" className="similar-results-error">{error}</div>}
+        {results === null && !error && (
+          <p className="similar-results-status">Searching…</p>
+        )}
+        {results && results.length === 0 && (
+          <p className="similar-results-empty">No similar items found above the 50% threshold.</p>
+        )}
+        {results && results.length > 0 && (
+          <ul className="similar-results-grid">
+            {results.map((r) => (
+              <li key={r.fileId} className="similar-results-item">
+                <div className="similar-results-thumb" aria-hidden="true">
+                  {r.thumbPath ? <img src={r.thumbPath} alt="" /> : <span>📄</span>}
+                </div>
+                <div className="similar-results-meta">
+                  <div className="similar-results-name" title={r.absPath}>{r.filename}</div>
+                  <div className="similar-results-desc">{r.description}</div>
+                  <div className="similar-results-score">{Math.round(r.score * 100)}%</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/sherlock/desktop/src/components/modals/TagRulesModal.css
+++ b/sherlock/desktop/src/components/modals/TagRulesModal.css
@@ -1,0 +1,96 @@
+.tag-rules-modal {
+  width: 580px;
+  max-width: 95vw;
+}
+
+.tag-rules-hint {
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  margin: 0 0 12px;
+}
+
+.tag-rules-loading {
+  color: var(--text-muted, #888);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.tag-rules-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.tag-rules-table th {
+  text-align: left;
+  padding: 4px 8px;
+  color: var(--text-muted, #888);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.tag-rules-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle, #222);
+}
+
+.tag-rule-disabled td {
+  opacity: 0.45;
+}
+
+.tag-rules-empty {
+  color: var(--text-muted, #888);
+  font-style: italic;
+  text-align: center;
+  padding: 12px !important;
+}
+
+.tag-rules-pattern code {
+  font-family: monospace;
+  font-size: 12px;
+  background: var(--bg-code, #1a1a1a);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.tag-rules-delete {
+  background: none;
+  border: none;
+  color: var(--text-muted, #888);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.tag-rules-delete:hover {
+  background: var(--danger-bg, #3a1a1a);
+  color: var(--danger, #e06c6c);
+}
+
+.tag-rules-add-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.tag-rules-input-pattern {
+  flex: 2;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.tag-rules-input-tag {
+  flex: 1;
+}
+
+.tag-rules-add-btn {
+  flex-shrink: 0;
+}
+
+.tag-rules-error {
+  color: var(--danger, #e06c6c);
+  font-size: 12px;
+  margin: 4px 0;
+}

--- a/sherlock/desktop/src/components/modals/TagRulesModal.tsx
+++ b/sherlock/desktop/src/components/modals/TagRulesModal.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from "react";
+import ModalOverlay from "./ModalOverlay";
+import * as api from "../../api";
+import type { TagRule } from "../../types";
+import "./shared-modal.css";
+import "./TagRulesModal.css";
+
+type Props = {
+  onClose: () => void;
+};
+
+export default function TagRulesModal({ onClose }: Props) {
+  const [rules, setRules] = useState<TagRule[]>([]);
+  const [pattern, setPattern] = useState("");
+  const [tag, setTag] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.listTagRules().then(setRules).finally(() => setLoading(false));
+  }, []);
+
+  async function handleAdd() {
+    const p = pattern.trim();
+    const t = tag.trim();
+    if (!p) { setError("Pattern is required"); return; }
+    if (!t) { setError("Tag is required"); return; }
+    try {
+      new RegExp(p); // validate regex
+    } catch {
+      setError("Invalid regex pattern");
+      return;
+    }
+    try {
+      const rule = await api.createTagRule(p, t);
+      setRules((prev) => [...prev, rule]);
+      setPattern("");
+      setTag("");
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function handleDelete(id: number) {
+    await api.deleteTagRule(id);
+    setRules((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  async function handleToggle(rule: TagRule) {
+    await api.setTagRuleEnabled(rule.id, !rule.enabled);
+    setRules((prev) =>
+      prev.map((r) => (r.id === rule.id ? { ...r, enabled: !r.enabled } : r))
+    );
+  }
+
+  return (
+    <ModalOverlay onBackdropClick={onClose}>
+      <div className="modal-base tag-rules-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Path-Pattern Tag Rules</h3>
+        <p className="tag-rules-hint">
+          When a file's relative path matches a regex pattern, the tag is
+          automatically added to its mentions at scan time.
+        </p>
+
+        {loading ? (
+          <p className="tag-rules-loading">Loading…</p>
+        ) : (
+          <table className="tag-rules-table">
+            <thead>
+              <tr>
+                <th>On</th>
+                <th>Pattern (regex)</th>
+                <th>Tag</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rules.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="tag-rules-empty">No rules yet</td>
+                </tr>
+              )}
+              {rules.map((rule) => (
+                <tr key={rule.id} className={rule.enabled ? "" : "tag-rule-disabled"}>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={rule.enabled}
+                      onChange={() => handleToggle(rule)}
+                      aria-label={`Enable rule ${rule.id}`}
+                    />
+                  </td>
+                  <td className="tag-rules-pattern">
+                    <code>{rule.pattern}</code>
+                  </td>
+                  <td className="tag-rules-tag">{rule.tag}</td>
+                  <td>
+                    <button
+                      type="button"
+                      className="tag-rules-delete"
+                      onClick={() => handleDelete(rule.id)}
+                      aria-label="Delete rule"
+                    >
+                      ✕
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <div className="tag-rules-add-row">
+          <input
+            type="text"
+            value={pattern}
+            onChange={(e) => { setPattern(e.target.value); setError(null); }}
+            placeholder="Regex pattern (e.g. ^Screenshots/)"
+            aria-label="Pattern"
+            className="tag-rules-input-pattern"
+          />
+          <input
+            type="text"
+            value={tag}
+            onChange={(e) => { setTag(e.target.value); setError(null); }}
+            placeholder="Tag"
+            aria-label="Tag"
+            className="tag-rules-input-tag"
+            onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+          />
+          <button type="button" onClick={handleAdd} className="tag-rules-add-btn">
+            Add
+          </button>
+        </div>
+        {error && <p className="tag-rules-error">{error}</p>}
+
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/sherlock/desktop/src/types.ts
+++ b/sherlock/desktop/src/types.ts
@@ -324,3 +324,15 @@ export type ReclusterProgress = {
   processed: number;
   result: ClusterResult | null;
 };
+
+export interface SimilarResult {
+  fileId: number;
+  rootId: number;
+  relPath: string;
+  absPath: string;
+  filename: string;
+  mediaType: string;
+  description: string;
+  thumbPath: string | null;
+  score: number;
+}

--- a/sherlock/desktop/src/types.ts
+++ b/sherlock/desktop/src/types.ts
@@ -358,6 +358,36 @@ export type TimelineBucket = {
   count: number;
 };
 
+// ── Auto-clustering ──────────────────────────────────────────────────
+
+export type EventSummary = {
+  id: number;
+  name: string;
+  startedAt: number;
+  endedAt: number;
+  fileCount: number;
+  coverFileId?: number | null;
+  centroidLat?: number | null;
+  centroidLon?: number | null;
+};
+
+export type TripSummary = {
+  id: number;
+  name: string;
+  startedAt: number;
+  endedAt: number;
+  eventCount: number;
+  coverFileId?: number | null;
+};
+
+export type Burst = {
+  coverFileId: number;
+  memberIds: number[];
+};
+
+/** Dedup policy strategy */
+export type DedupStrategy = "keepLargest" | "keepOldest" | "keepInAlbum";
+
 /** A parsed chip in the ChipSearchBar */
 export type SearchChip = {
   id: string;

--- a/sherlock/desktop/src/types.ts
+++ b/sherlock/desktop/src/types.ts
@@ -336,3 +336,32 @@ export interface SimilarResult {
   thumbPath: string | null;
   score: number;
 }
+
+/** Autocomplete suggestion from suggest_cmd */
+export type Suggestion = {
+  label: string;
+  /** "person" | "camera" | "lens" | "mention" */
+  kind: string;
+  count: number;
+};
+
+/** Camera/lens filter option from list_cameras_cmd / list_lenses_cmd */
+export type FilterOption = {
+  value: string;
+  count: number;
+};
+
+/** One monthly bucket from list_timeline_buckets_cmd */
+export type TimelineBucket = {
+  /** ISO-8601 month, e.g. "2023-06" */
+  bucket: string;
+  count: number;
+};
+
+/** A parsed chip in the ChipSearchBar */
+export type SearchChip = {
+  id: string;
+  /** "camera" | "lens" | "time" | "person" | "album" | "subdir" | "media" | "date_from" | "date_range" */
+  facet: string;
+  value: string;
+};

--- a/sherlock/desktop/src/types.ts
+++ b/sherlock/desktop/src/types.ts
@@ -208,6 +208,7 @@ export type FileProperties = {
 export type Album = {
   id: number;
   name: string;
+  tag: string;
   createdAt: number;
   fileCount: number;
 };
@@ -217,6 +218,22 @@ export type SmartFolder = {
   name: string;
   query: string;
   createdAt: number;
+};
+
+export type TagRule = {
+  id: number;
+  pattern: string;
+  tag: string;
+  enabled: boolean;
+};
+
+export type SavedSearch = {
+  id: number;
+  name: string;
+  query: string;
+  notify: boolean;
+  lastMatchId: number;
+  lastCheckedAt: number;
 };
 
 export type PdfPassword = {


### PR DESCRIPTION
## Summary

Full implementation of the Auto-Organize & Findability roadmap — 6 phases, 21 features, shipping as a single branch.

### Phase 1 — EXIF & Filter Foundations
- Camera / lens / time-of-day metadata extracted from EXIF at scan time
- Sidebar filter UI + autocomplete for `camera:`, `lens:`, `time:` tokens
- Migration 13: `camera`, `lens`, `focal_length_mm`, `aperture`, `iso`, `shutter_speed` columns

### Phase 2 — Smart Search Bar
- `ChipSearchBar`: renders structured tokens (`camera:`, `lens:`, `face:`, `album:`, `blur:`, etc.) as removable chips with inline text
- `TagAutocomplete`: ranked prefix suggestions from canonical mentions, people, cameras, lenses
- `TimelineHeatmap`: monthly photo-count heatmap in sidebar with click-to-filter

### Phase 3 — Event Clusters & Burst Collapse
- Burst collapse: consecutive near-identical frames within a 2s window collapsed in the grid (first frame representative)
- Blur score computed at thumbnail time via Laplacian variance; stored as `blur_score REAL`
- Year-in-Review album generator (top 1 photo per month by confidence)
- Dedup policies: `keep_newest`, `keep_oldest`, `keep_largest`, `keep_smallest`

### Phase 4 — Color & Sensor Intelligence
- `dominant_color` stored as `INTEGER` (0xRRGGBB) from thumbnail k-means at scan time
- `color:#RRGGBB` query token → Manhattan distance WHERE clause in search (threshold 120)
- `blur:true` / `blur:false` filter tokens + toolbar blur-cycle toggle (all → sharp → blurry)
- QR/barcode detection via `rqrr` crate; detected text appended to `extracted_text`

### Phase 5 — Tag Rules, Face Smart Albums, Album Inheritance
- Path-pattern auto-tag rules: regex compiled once, matched against `rel_path` at scan time → `canonical_mentions`
- `TagRulesModal`: full CRUD (add / enable-toggle / delete) with client-side regex validation
- Face smart albums: "Create Smart Album" in FacesView context menu → `person:Name` smart folder
- Album tag inheritance: adding files to a tagged album appends the album tag to `canonical_mentions`

### Phase 6 — Saved Searches & Ambient Similar
- Saved searches: save any query by name; listed in sidebar with bell-alert toggle and delete
- `useAmbientSimilar` hook: 300ms debounced `find_similar_cmd` call in PreviewModal, shows up to 5 similar files in a sidebar panel
- Navigate to similar results in-place or synthesize a standalone preview item

## Test plan
- [ ] Rust: `cargo test` — 384 tests passing
- [ ] Frontend: `npm run test` — 343 tests passing
- [ ] CI: Linux / macOS / Windows builds must succeed
- [ ] Smoke test: scan a folder, verify camera/lens filters, chip search bar, blur toggle, color search, tag rules, year review, saved searches, ambient similar panel